### PR TITLE
add more python versions to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,13 @@ concurrency:
 jobs:
   ci-pip:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
       - run: pip install -e .[tests] --verbose
       - run: python -m pytest -v


### PR DESCRIPTION
- now test Python 3.7, 3.8, 3.9 on windows
- (one) difficulty with adding other python versions / operating systems is the lack of wxPython wheels