### PR TITLE
add delays after trial and block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ classifiers = [
 dependencies = ["psychopy", "numpy"]
 dynamic = ["version"]
 
+[project.scripts]
+motor_task_prototype = "motor_task_prototype.__main__:main"
+
 [project.urls]
 Github = "https://github.com/ssciwr/motor-task-prototype"
 Issues = "https://github.com/ssciwr/motor-task-prototype/issues"

--- a/src/motor_task_prototype/__main__.py
+++ b/src/motor_task_prototype/__main__.py
@@ -1,3 +1,4 @@
+import logging
 from typing import cast
 
 import motor_task_prototype as mtp
@@ -6,6 +7,9 @@ from psychopy import core
 
 
 def main() -> None:
+    logging.basicConfig(
+        format="%(levelname)s %(module)s.%(funcName)s.%(lineno)d :: %(message)s"
+    )
     user_choices = mtp.setup()
     if user_choices is not None:
         if user_choices.run_task:

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -4,11 +4,74 @@ import numpy as np
 
 def test_default_trial() -> None:
     trial = mtptrial.default_trial()
-    assert len(trial) == 13
+    assert len(trial) == 15
     assert len(trial["target_indices"].split(" ")) == trial["num_targets"]
 
 
-def test_validate_trial() -> None:
+def test_import_trial() -> None:
+    default_trial = mtptrial.default_trial()
+    trial_dict = {
+        "weight": 2,
+        "num_targets": 6,
+        "target_order": "clockwise",
+        "target_indices": "0 1 2 3 4 5",
+        "target_duration": 3,
+        "inter_target_duration": 0,
+        "target_distance": 0.3,
+        "target_size": 0.03,
+        "central_target_size": 0.01,
+        "play_sound": True,
+        "show_cursor": False,
+        "show_cursor_path": True,
+        "cursor_rotation_degrees": 45,
+        "post_trial_delay": 0.2,
+        "post_block_delay": 2.0,
+    }
+    # all valid keys are imported
+    trial = mtptrial.import_trial(trial_dict)
+    for key in trial:
+        assert trial[key] == trial_dict[key]  # type: ignore
+    # if any keys are missing, default values are used instead
+    missing_keys = ["weight", "cursor_rotation_degrees", "post_trial_delay"]
+    for key in missing_keys:
+        trial_dict.pop(key)
+    # unknown keys are ignored
+    trial_dict["unknown_key1"] = "ignore me"
+    trial_dict["unknown_key2"] = False
+    trial = mtptrial.import_trial(trial_dict)
+    for key in trial:
+        if key in missing_keys:
+            assert trial[key] == default_trial[key]  # type: ignore
+        else:
+            assert trial[key] == trial_dict[key]  # type: ignore
+
+
+def test_validate_trial_durations() -> None:
+    trial = mtptrial.default_trial()
+    # positive durations are not modified
+    trial["target_duration"] = 1
+    trial["inter_target_duration"] = 0.1
+    trial["post_trial_delay"] = 0.2
+    trial["post_block_delay"] = 0.7
+    vtrial = mtptrial.validate_trial(trial)
+    assert vtrial["target_duration"] == 1
+    assert vtrial["inter_target_duration"] == 0.1
+    assert vtrial["post_trial_delay"] == 0.2
+    assert vtrial["post_block_delay"] == 0.7
+    # negative durations are cast to zero
+    trial["target_duration"] = -1
+    trial["inter_target_duration"] = -0.1
+    trial["post_trial_delay"] = -0.2
+    trial["post_block_delay"] = -0.7
+    vtrial = mtptrial.validate_trial(trial)
+    assert vtrial["target_duration"] == 0
+    assert vtrial["inter_target_duration"] == 0
+    assert vtrial["post_trial_delay"] == 0
+    assert vtrial["post_block_delay"] == 0
+    assert vtrial["post_block_delay"] == 0
+
+
+def test_validate_trial_target_order() -> None:
     trial = mtptrial.default_trial()
     assert isinstance(trial["target_indices"], str)
     # clockwise


### PR DESCRIPTION
- after each trial wait `post_trial_delay`
- unless it is the last trial of the block, then wait `post_block_delay`
- resolves #40

also

- separate trial import from trial validation
- use defaults for missing keys on import, but log a warning
  - allows for basic forwards-compatibility of trials format
