### PR TITLE
fix bug in `make_targets` for 1 target and add vis tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install Mesa 3D to get OpenGL support without a GPU
+        shell: cmd
+        run: |
+          curl.exe -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/22.1.7/mesa3d-22.1.7-release-msvc.7z
+          7z.exe x mesa.7z
+          systemwidedeploy.cmd 1
       - run: pip install -e .[tests] --verbose
       - run: python -m pytest --cov=motor_task_prototype --cov-report=xml -v
       - uses: codecov/codecov-action@v3

--- a/src/motor_task_prototype/__init__.py
+++ b/src/motor_task_prototype/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     "display_results",
 ]
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/src/motor_task_prototype/task.py
+++ b/src/motor_task_prototype/task.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 from typing import Union
 
@@ -103,7 +104,7 @@ class MotorTask:
             while clock.getTime() < post_trial_delay:
                 win.flip()
         if win.nDroppedFrames > 0:
-            print(f"Warning: dropped {win.nDroppedFrames} frames")
+            logging.warning(f"Dropped {win.nDroppedFrames} frames")
         mouse.setVisible(True)
         win.close()
         return self.trial_handler

--- a/src/motor_task_prototype/vis.py
+++ b/src/motor_task_prototype/vis.py
@@ -48,7 +48,8 @@ def make_targets(
         units="height",
         fieldShape="circle",
         nElements=n_circles + 1,
-        sizes=[2.0 * point_radius] * n_circles + [2.0 * center_point_radius],
+        sizes=[[2.0 * point_radius] * 2] * n_circles
+        + [[2.0 * center_point_radius] * 2],
         xys=points_on_circle(n_circles, radius, include_centre=True),
         elementTex=None,
         elementMask="circle",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from psychopy.visual.window import Window
+
+
+# fixture to create a wxPython Window for testing gui functions
+@pytest.fixture(scope="session")
+# session scope means this is only called once by the test suite
+def window() -> Window:
+    window = Window(fullscr=False, units="height", size=(800, 600))
+    # yield is like return but control flow returns here afterwards
+    yield window
+    # clean up window once all tests are done
+    window.close()

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,0 +1,84 @@
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+import motor_task_prototype.vis as mtpvis
+import numpy as np
+import pytest
+from psychopy.visual.window import Window
+
+
+def test_make_cursor(window: Window) -> None:
+    cursor = mtpvis.make_cursor(window)
+    assert np.allclose(cursor.pos, [0, 0])
+
+
+@pytest.mark.parametrize(
+    "args,xys",
+    [
+        (
+            {
+                "n_circles": 1,
+                "radius": 0.5,
+                "point_radius": 0.1,
+                "center_point_radius": 0.05,
+            },
+            [(0, 0.5), (0, 0)],
+        ),
+        (
+            {
+                "n_circles": 2,
+                "radius": 0.3,
+                "point_radius": 0.02,
+                "center_point_radius": 0.04,
+            },
+            [(0, 0.3), (0, -0.3), (0, 0)],
+        ),
+        (
+            {
+                "n_circles": 4,
+                "radius": 0.8,
+                "point_radius": 0.2,
+                "center_point_radius": 0.07,
+            },
+            [(0, 0.8), (0.8, 0), (0, -0.8), (-0.8, 0), (0, 0)],
+        ),
+    ],
+)
+def test_make_targets(
+    window: Window, args: Dict, xys: List[Tuple[float, float]]
+) -> None:
+    targets = mtpvis.make_targets(window, **args)
+    nElements = args["n_circles"] + 1
+    assert targets.nElements == nElements
+    # shape of sizes is x,y pair for each element
+    assert targets.sizes.shape == (nElements, 2)
+    # size is circumference of circle in both x and y directions
+    point_size = 2 * args["point_radius"]
+    for size in targets.sizes[0:-1]:
+        assert np.allclose(size, [point_size, point_size])
+    center_point_size = 2 * args["center_point_radius"]
+    assert np.allclose(targets.sizes[-1], [center_point_size, center_point_size])
+    assert np.allclose(targets.xys, xys)
+
+
+@pytest.mark.parametrize("n_targets", [1])
+def test_update_target_colors(window: Window, n_targets: int) -> None:
+    grey = (0.1, 0.1, 0.1)
+    red = (1.0, -1.0, -1.0)
+    targets = mtpvis.make_targets(window, n_targets, 0.5, 0.05, 0.05)
+    n_elem = n_targets + 1
+    # calling without specifying an index makes all elements grey
+    mtpvis.update_target_colors(targets)
+    assert targets.colors.shape == (n_elem, 3)
+    for color in targets.colors:
+        assert np.allclose(color, grey)
+    # calling with index makes that element red, the rest grey
+    for index in range(n_elem):
+        mtpvis.update_target_colors(targets, index=index)
+        assert targets.colors.shape == (n_elem, 3)
+        for i in range(n_elem):
+            if i == index:
+                assert np.allclose(targets.colors[i], red)
+            else:
+                assert np.allclose(targets.colors[i], grey)


### PR DESCRIPTION
- ElementArrayStim sizes should be array of `(x,y)` sizes for each element
  - we were passing an array of scalar size values
  - psychopy silently fixes this by converting it to a 2d array
  - this conversion is buggy/ambiguous for 2 elements (`[s0,s1]` -> `[(s0,s1),(s0,s1)]` instead of `[(s0,s0),(s1,s1)]`)
  - we now pass an array of `(s,s)` sizes instead of an array of `s`
- Add vis tests
  - add conftest.py with a fixture to create a session scope wxPython Window for testing gui functions
