### PR TITLE
add GUI tests of task and linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci-pip:
-    runs-on: ${{ matrix.os }}
+  windows:
+    runs-on: windows-latest
     strategy:
       matrix:
-        os: ["windows-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -28,11 +27,38 @@ jobs:
       - name: Install Mesa 3D to get OpenGL support without a GPU
         uses: ssciwr/setup-mesa-dist-win@v1
       - run: pip install -e .[tests] --verbose
-      - run: pytest -k test_display_results
       - run: python -m pytest --cov=motor_task_prototype --cov-report=xml -v
       - uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
-          name: ${{ matrix.os }}-${{ matrix.python-version }}
+          name: windows-${{ matrix.python-version }}
+          fail_ci_if_error: true
+          verbose: true
+  ubuntu:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      # various psychopy system dependencies
+      - run: sudo apt-get update -yy && sudo apt-get install -yy libasound2-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev libsndfile1-dev libportmidi-dev liblo-dev libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0 freeglut3-dev scrot
+      # get wxPython wheel
+      - run: pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/ wxPython
+      # enable colours in logs
+      - run: echo "FORCE_COLOR=1" >> $GITHUB_ENV
+      - run: echo "TERM=xterm-256color" >> $GITHUB_ENV
+      # psychopy requires that the python executable has permission to set its priority level
+      - run: sudo setcap cap_sys_nice+ep `python -c "import os; import sys; print(os.path.realpath(sys.executable))"`
+      - run: pip install -e .[tests] --verbose
+      # run tests using Xvfb to have a display server
+      - run: xvfb-run -a --server-args="-screen 0 1024x768x24" python -m pytest --cov=motor_task_prototype --cov-report=xml -v -s
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
+          name: ubuntu-${{ matrix.python-version }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build docs and deploy to gh-pages
+name: Documentation
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # motor-task-prototype
 
-[![Build docs and deploy to gh-pages](https://github.com/ssciwr/motor-task-prototype/actions/workflows/docs.yml/badge.svg)](https://ssciwr.github.io/motor-task-prototype)
+[![Documentation](https://github.com/ssciwr/motor-task-prototype/actions/workflows/docs.yml/badge.svg)](https://ssciwr.github.io/motor-task-prototype)
 [![CI](https://github.com/ssciwr/motor-task-prototype/actions/workflows/ci.yml/badge.svg)](https://github.com/ssciwr/motor-task-prototype/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/ssciwr/motor-task-prototype/branch/main/graph/badge.svg?token=sjsAdTyLH1)](https://codecov.io/gh/ssciwr/motor-task-prototype)
 

--- a/docs/developer/install.rst
+++ b/docs/developer/install.rst
@@ -24,7 +24,7 @@ To clone the repo, make an editable installation and run the tests:
     git clone https://github.com/ssciwr/motor-task-prototype.git
     cd motor-task-prototype
     pip install -e .[tests,docs]
-    pytest
+    xvfb-run pytest
 
 To build the docs (in ``docs/_build/html/index.html``)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Issues = "https://github.com/ssciwr/motor-task-prototype/issues"
 Documentation = "https://ssciwr.github.io/motor-task-prototype/"
 
 [project.optional-dependencies]
-tests = ["pytest", "pytest-cov", "pyautogui"]
+tests = ["pytest", "pytest-cov", "pyautogui", "ascii-magic"]
 docs = [
   "ipykernel",
   "matplotlib",

--- a/src/motor_task_prototype/task.py
+++ b/src/motor_task_prototype/task.py
@@ -28,9 +28,9 @@ class MotorTask:
             [trial], nReps=1, method="sequential", originPath=-1
         )
 
-    def run(self) -> TrialHandlerExt:
-        win = Window(fullscr=True, units="height")
-        mouse = Mouse(visible=False)
+    def run(self, winType: str = "pyglet") -> TrialHandlerExt:
+        win = Window(fullscr=True, units="height", winType=winType)
+        mouse = Mouse(visible=False, win=win)
         clock = Clock()
         kb = Keyboard()
         trial_counts = np.zeros((len(self.trial_handler.trialList),), dtype=int)

--- a/src/motor_task_prototype/vis.py
+++ b/src/motor_task_prototype/vis.py
@@ -77,8 +77,8 @@ def draw_and_flip(
     win.flip()
 
 
-def display_results(results: TrialHandlerExt) -> None:
-    win = Window(fullscr=True, units="height")
+def display_results(results: TrialHandlerExt, winType: str = "pyglet") -> None:
+    win = Window(fullscr=True, units="height", winType=winType)
     clock = Clock()
     kb = Keyboard()
     # for now just get the data from the first trial

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,14 @@ def tests_init() -> None:
 
 
 # fixture to create a wxPython Window for testing gui functions
+# GLFW backend used for tests as it works better with Xvfb
 @pytest.fixture()
 def window() -> Window:
-    window = Window(fullscr=False, units="height", size=(800, 600))
+    window = Window(
+        fullscr=True,
+        units="height",
+        winType="glfw",
+    )
     # yield is like return except control flow returns here afterwards
     yield window
     # clean up window

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,77 @@
+import multiprocessing
+import sys
+from time import sleep
+from typing import Tuple
+
+import ascii_magic
+import motor_task_prototype.task as mtptask
+import numpy as np
+import pyautogui
+import pytest
+from motor_task_prototype.geom import points_on_circle
+from motor_task_prototype.trial import default_trial
+
+
+def ascii_screenshot() -> None:
+    print(f"\n{ascii_magic.from_image(pyautogui.screenshot())}\n")
+
+
+def pixel_color(pixel: Tuple[float, float], color: Tuple[int, int, int]) -> bool:
+    return np.allclose(pyautogui.screenshot().load()[pixel], color)
+
+
+def pos_to_pixels(pos: Tuple[float, float]) -> Tuple[float, float]:
+    # pos is in units of screen height, with 0,0 in centre of screen
+    width, height = pyautogui.size()
+    # return equivalent position in pixels with 0,0 in top left of screen
+    pixels = width / 2.0 + pos[0] * height, height / 2.0 - pos[1] * height
+    return pixels
+
+
+def wrap_task(trial: mtptask.MotorTaskTrial, queue: multiprocessing.Queue) -> None:
+    task = mtptask.MotorTask(trial)
+    results = task.run(winType="glfw")
+    queue.put(results)
+
+
+pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="GUI interaction tests not yet working on windows CI",
+)
+
+
+def test_task() -> None:
+    trial = default_trial()
+    # disable sounds due to issues with sounds within tests on linux
+    trial["play_sound"] = False
+    movement_time = 0.5
+    queue: multiprocessing.Queue = multiprocessing.Queue()
+    process = multiprocessing.Process(
+        target=wrap_task,
+        name="task",
+        args=(
+            trial,
+            queue,
+        ),
+    )
+    process.start()
+    target_pixels = [
+        pos_to_pixels(pos)
+        for pos in points_on_circle(
+            trial["num_targets"], trial["target_distance"], include_centre=False
+        )
+    ]
+    for pixel in target_pixels:
+        # wait until target is activated
+        while not pixel_color(pixel, (255, 0, 0)):
+            sleep(0.1)
+        ascii_screenshot()
+        # move mouse to target
+        pyautogui.moveTo(pixel[0], pixel[1], movement_time)
+    results = queue.get()
+    # check that we hit all the targets
+    for timestamps, positions in zip(
+        results.data["timestamps"][0][0], results.data["mouse_positions"][0][0]
+    ):
+        assert timestamps[-1] < 0.5 * trial["target_duration"]
+    process.join()

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,4 +1,5 @@
-import multiprocessing
+import sys
+import threading
 from time import sleep
 from typing import Dict
 from typing import List
@@ -88,16 +89,24 @@ def test_update_target_colors(window: Window, n_targets: int) -> None:
                 assert np.allclose(targets.colors[i], grey)
 
 
+pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="GUI interaction tests not yet working on windows CI",
+)
+
+
 def test_display_results(fake_trial: TrialHandlerExt) -> None:
-    # pyglet is not threadsafe so GUI code must run in separate process
-    # (if threading is used instead get a variety of strange errors)
-    process = multiprocessing.Process(
-        target=mtpvis.display_results, name="display_results", args=(fake_trial,)
+    process = threading.Thread(
+        target=mtpvis.display_results,
+        name="display_results",
+        args=(
+            fake_trial,
+            "glfw",
+        ),
     )
     process.start()
     # wait for display_results screen to be ready
     sleep(1)
     # press escape to exit
     pyautogui.typewrite(["escape"])
-    sleep(1)
     process.join()


### PR DESCRIPTION
- add task GUI test
  - include screenshots as ascii-art in pytest output to aid debugging
- add `winType` option whenever a psychopy `Window` is created to choose the backend
  - default is still `pyglet`
  - allows tests use `glfw` as it has better Xvfb support
- use threading instead of multiprocessing in gui interaction tests
  - glfw backend works with threads and in fact had issues with multiple processes
- add linux CI config
  - resolves #54
