### PR TITLE
add splash screen and metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Issues = "https://github.com/ssciwr/motor-task-prototype/issues"
 Documentation = "https://ssciwr.github.io/motor-task-prototype/"
 
 [project.optional-dependencies]
-tests = ["pytest", "pytest-cov", "pyautogui", "ascii-magic"]
+tests = ["pytest", "pytest-cov", "pyautogui", "ascii-magic", "keyboard"]
 docs = [
   "ipykernel",
   "matplotlib",

--- a/src/motor_task_prototype/__init__.py
+++ b/src/motor_task_prototype/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "display_results",
 ]
 
-__version__ = "0.0.11"
+__version__ = "0.1.0"

--- a/src/motor_task_prototype/meta.py
+++ b/src/motor_task_prototype/meta.py
@@ -1,0 +1,73 @@
+import copy
+import sys
+from typing import Dict
+from typing import Optional
+
+from psychopy import core
+from psychopy.gui import DlgFromDict
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+MotorTaskMetadata = TypedDict(
+    "MotorTaskMetadata",
+    {
+        "name": str,
+        "subject": str,
+        "date": str,
+        "author": str,
+        "display_title": str,
+        "display_text1": str,
+        "display_text2": str,
+        "display_text3": str,
+        "display_text4": str,
+    },
+)
+
+
+def default_metadata() -> MotorTaskMetadata:
+    return {
+        "name": "Experiment",
+        "subject": "Joe Smith",
+        "date": "2022/01/01",
+        "author": "Author",
+        "display_title": "Welcome to the experiment",
+        "display_text1": "When a target is presented, "
+        "you will hear an audible tone and the target circle will turn red.",
+        "display_text2": "Try to move the cursor to the red circle "
+        "as quickly and accurately as you can.",
+        "display_text3": "You can abort the experiment at any time "
+        "by pressing the Escape key.",
+        "display_text4": "Otherwise, press Enter " "when you are ready to begin.",
+    }
+
+
+def metadata_labels() -> Dict:
+    return {
+        "name": "Experiment Name",
+        "subject": "Subject Name",
+        "date": "Date",
+        "author": "Author",
+        "display_title": "Title text to display",
+        "display_text1": "Main text line 1",
+        "display_text2": "Main text line 2",
+        "display_text3": "Main text line 3",
+        "display_text4": "Main text line 4",
+    }
+
+
+def get_metadata_from_user(
+    initial_metadata: Optional[MotorTaskMetadata] = None,
+) -> MotorTaskMetadata:
+    if initial_metadata:
+        metadata = copy.deepcopy(initial_metadata)
+    else:
+        metadata = default_metadata()
+    dialog = DlgFromDict(
+        metadata, title="Experiment metadata", labels=metadata_labels(), sortKeys=False
+    )
+    if not dialog.OK:
+        core.quit()
+    return metadata

--- a/src/motor_task_prototype/setup.py
+++ b/src/motor_task_prototype/setup.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import motor_task_prototype as mtp
 import wx
+from motor_task_prototype.meta import get_metadata_from_user
 from motor_task_prototype.task import new_experiment_from_dicts
 from motor_task_prototype.task import new_experiment_from_trialhandler
 from motor_task_prototype.trial import describe_trials
@@ -19,6 +20,31 @@ from psychopy.misc import fromFile
 class UserChoices:
     run_task: bool
     experiment: TrialHandlerExt
+
+
+def get_experiment_from_user() -> TrialHandlerExt:
+    metadata = get_metadata_from_user()
+    trials: List[MotorTaskTrial] = []
+    initial_trial = None
+    add_another_trial = True
+    while add_another_trial:
+        if len(trials) > 0:
+            initial_trial = trials[-1]
+        trials.append(get_trial_from_user(initial_trial))
+        dia_yes_no = wx.MessageDialog(
+            None,
+            "Trials in experiment:\n\n"
+            + describe_trials(trials)
+            + "\n\nAdd another trial to the experiment?",
+            "Add another trial?",
+            style=wx.YES_NO,
+        )
+        result_yes_no = dia_yes_no.ShowModal()
+        dia_yes_no.Destroy()
+        if result_yes_no != wx.ID_YES:
+            add_another_trial = False
+    display_options = get_display_options_from_user()
+    return new_experiment_from_dicts(trials, display_options, metadata)
 
 
 def setup() -> Optional[UserChoices]:
@@ -42,27 +68,7 @@ def setup() -> Optional[UserChoices]:
     if result != wx.ID_OK:
         return None
     if selection == 0:
-        trials: List[MotorTaskTrial] = []
-        initial_trial = None
-        add_another_trial = True
-        while add_another_trial:
-            if len(trials) > 0:
-                initial_trial = trials[-1]
-            trials.append(get_trial_from_user(initial_trial))
-            dia_yes_no = wx.MessageDialog(
-                None,
-                "Trials in experiment:\n\n"
-                + describe_trials(trials)
-                + "\n\nAdd another trial to the experiment?",
-                "Add another trial?",
-                style=wx.YES_NO,
-            )
-            result_yes_no = dia_yes_no.ShowModal()
-            dia_yes_no.Destroy()
-            if result_yes_no != wx.ID_YES:
-                add_another_trial = False
-        display_options = get_display_options_from_user()
-        return UserChoices(True, new_experiment_from_dicts(trials, display_options))
+        return UserChoices(True, get_experiment_from_user())
     elif selection == 1:
         filename = fileOpenDlg(allowed="Psydat files (*.psydat)")
         if filename is None or len(filename) < 1:

--- a/src/motor_task_prototype/trial.py
+++ b/src/motor_task_prototype/trial.py
@@ -1,7 +1,9 @@
 import copy
 import logging
 import sys
+from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Union
 
 import numpy as np
@@ -71,15 +73,8 @@ def default_trial() -> MotorTaskTrial:
     }
 
 
-def get_trial_from_user(
-    initial_trial: MotorTaskTrial = None,
-) -> MotorTaskTrial:
-    if initial_trial:
-        trial = copy.deepcopy(initial_trial)
-    else:
-        trial = default_trial()
-    order_of_targets = [trial["target_order"]]
-    labels = {
+def trial_labels() -> Dict:
+    return {
         "weight": "Repetitions",
         "num_targets": "Number of targets",
         "target_order": "Target order",
@@ -99,12 +94,22 @@ def get_trial_from_user(
         "post_block_delay": "Delay after last trial (secs)",
         "post_block_display_results": "Display results after this block",
     }
+
+
+def get_trial_from_user(
+    initial_trial: Optional[MotorTaskTrial] = None,
+) -> MotorTaskTrial:
+    if initial_trial:
+        trial = copy.deepcopy(initial_trial)
+    else:
+        trial = default_trial()
+    order_of_targets = [trial["target_order"]]
     for target_order in ["clockwise", "anti-clockwise", "random", "fixed"]:
         if target_order != order_of_targets[0]:
             order_of_targets.append(target_order)
     trial["target_order"] = order_of_targets
     dialog = DlgFromDict(
-        trial, title="Motor task settings", labels=labels, sortKeys=False
+        trial, title="Motor task settings", labels=trial_labels(), sortKeys=False
     )
     if not dialog.OK:
         core.quit()

--- a/tests/helpers/gui_test_utils.py
+++ b/tests/helpers/gui_test_utils.py
@@ -1,0 +1,114 @@
+import queue
+import sys
+import threading
+from time import sleep
+from typing import Callable
+from typing import Tuple
+
+import ascii_magic
+
+if sys.platform.startswith("win"):
+    # use alternative library to generate keyboard events on windows
+    import keyboard
+import numpy as np
+import pyautogui
+
+
+# print screenshot as ascii art to terminal for debugging
+def ascii_screenshot() -> None:
+    print(f"\n{ascii_magic.from_image(pyautogui.screenshot())}\n", flush=True)
+
+
+# simulate user pressing Enter key
+def press_enter() -> None:
+    if sys.platform.startswith("win"):
+        # `keyboard` works on windows but needs sudo on linux
+        keyboard.send("enter")
+    else:
+        # `pyautogui` in principle works everywhere, but
+        # key events don't seem to do actually do anything on windows
+        pyautogui.press("enter")
+
+
+# return true if pixel or any neighbours is of the desired color
+def pixel_color(pixel: Tuple[float, float], color: Tuple[int, int, int]) -> bool:
+    img = pyautogui.screenshot().load()
+    for dx in [0, 1, -1]:
+        for dy in [0, 1, -1]:
+            p = (pixel[0] + dx, pixel[1] + dy)
+            if np.allclose(img[p], color):
+                return True
+    return False
+
+
+# convert a position in units of screen height to a pair of pixels
+def pos_to_pixels(pos: Tuple[float, float]) -> Tuple[float, float]:
+    # pos is in units of screen height, with 0,0 in centre of screen
+    width, height = pyautogui.size()
+    # return equivalent position in pixels with 0,0 in top left of screen
+    pixels = width / 2.0 + pos[0] * height, height / 2.0 - pos[1] * height
+    return pixels
+
+
+# RMS difference between two arrays
+def rms_diff(a: np.ndarray, b: np.ndarray) -> float:
+    return np.sqrt(np.mean(np.square(a - b)))
+
+
+# wait for screen to change, return screenshot
+def get_screenshot_when_ready(
+    screenshot_before: np.ndarray,
+    screenshot_queue: queue.Queue,
+    min_rms_diff: float = 0.1,
+    delay_between_screenshots: float = 0.5,
+) -> None:
+    s0 = np.asarray(screenshot_before)
+    sleep(delay_between_screenshots)
+    img = pyautogui.screenshot()
+    s = np.asarray(img)
+    # wait until
+    #   - screen differs significantly from original screenshot
+    #   - is not all black (xvfb initial screen)
+    #   - is not all grey (psychopy initial screen)
+    black = 0.0
+    grey = 128.0
+    attempts = 0
+    while rms_diff(s, s0) < min_rms_diff or np.mean(s) in [black, grey]:
+        sleep(delay_between_screenshots)
+        img = pyautogui.screenshot()
+        s = np.asarray(img)
+        attempts += 1
+        if attempts > 10:
+            print("Stuck waiting for screen to be ready", flush=True)
+            print(f"Mean pixel: {np.mean(s)}", flush=True)
+            ascii_screenshot()
+    print(f"\n{ascii_magic.from_image(img)}\n", flush=True)
+    screenshot_queue.put(s)
+    # press enter to close screen
+    press_enter()
+    return
+
+
+# call target with args, get screenshot when ready, press Enter to close screen
+def call_target_and_get_screenshot(target: Callable, args: Tuple) -> np.ndarray:
+    screenshot_queue: queue.Queue = queue.Queue()
+    screenshot_before = pyautogui.screenshot()
+    screenshot_thread = threading.Thread(
+        target=get_screenshot_when_ready,
+        name="display_results",
+        args=(screenshot_before, screenshot_queue),
+    )
+    screenshot_thread.start()
+    target(*args)
+    screenshot_thread.join()
+    return screenshot_queue.get()
+
+
+# return fraction of pixels in image of the supplied color
+def pixel_color_fraction(img: np.ndarray, color: Tuple[int, int, int]) -> float:
+    return np.count_nonzero((img == np.array(color)).all(axis=2)) / (img.size / 3)
+
+
+# return fraction of pixels in current screen of the supplied color
+def screenshot_pixel_color_fraction(color: Tuple[int, int, int]) -> float:
+    return pixel_color_fraction(np.asarray(pyautogui.screenshot()), color)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,8 @@
+import motor_task_prototype.meta as mtpmeta
+
+
+def test_metadata_labels() -> None:
+    metadata = mtpmeta.default_metadata()
+    labels = mtpmeta.metadata_labels()
+    assert len(metadata) == len(labels)
+    assert metadata.keys() == labels.keys()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,43 +1,14 @@
-import multiprocessing
+import threading
 from time import sleep
 from typing import List
 from typing import Tuple
 
-import ascii_magic
+import gui_test_utils as gtu
 import motor_task_prototype.task as mtptask
-import numpy as np
 import pyautogui
 from motor_task_prototype.geom import points_on_circle
 from psychopy.data import TrialHandlerExt
-
-
-def ascii_screenshot() -> None:
-    print(f"\n{ascii_magic.from_image(pyautogui.screenshot())}\n")
-
-
-# return true if pixel or any neighbours is of the desired color
-def pixel_color(pixel: Tuple[float, float], color: Tuple[int, int, int]) -> bool:
-    img = pyautogui.screenshot().load()
-    for dx in [0, 1, -1]:
-        for dy in [0, 1, -1]:
-            p = (pixel[0] + dx, pixel[1] + dy)
-            if np.allclose(img[p], color):
-                return True
-    return False
-
-
-def pos_to_pixels(pos: Tuple[float, float]) -> Tuple[float, float]:
-    # pos is in units of screen height, with 0,0 in centre of screen
-    width, height = pyautogui.size()
-    # return equivalent position in pixels with 0,0 in top left of screen
-    pixels = width / 2.0 + pos[0] * height, height / 2.0 - pos[1] * height
-    return pixels
-
-
-def wrap_task(experiment: TrialHandlerExt, queue: multiprocessing.Queue) -> None:
-    task = mtptask.MotorTask(experiment)
-    results = task.run(win_type="glfw")
-    queue.put(results)
+from psychopy.visual.window import Window
 
 
 def move_mouse_to_target(
@@ -46,49 +17,52 @@ def move_mouse_to_target(
     movement_time: float = 0.2,
 ) -> None:
     # wait until target is activated
-    while not pixel_color(target_pixel, target_color):
-        sleep(0.1)
-    # ascii image of screen for debugging logs
-    ascii_screenshot()
+    attempts = 0
+    while not gtu.pixel_color(target_pixel, target_color):
+        sleep(0.2)
+        # press Enter in case we are looking at a splash / display_results screen
+        gtu.press_enter()
+        attempts += 1
+        if attempts > 10:
+            print(f"Stuck waiting for target at {target_pixel} to activate", flush=True)
+            gtu.ascii_screenshot()
+    gtu.ascii_screenshot()
     # move mouse to target
     pyautogui.moveTo(target_pixel[0], target_pixel[1], movement_time)
 
 
 def do_task(
     experiment: TrialHandlerExt, target_pixels: List[List[Tuple[float, float]]]
-) -> TrialHandlerExt:
-    queue: multiprocessing.Queue = multiprocessing.Queue()
-    process = multiprocessing.Process(
-        target=wrap_task,
-        name="task",
-        args=(
-            experiment,
-            queue,
-        ),
-    )
-    process.start()
+) -> None:
+    gtu.ascii_screenshot()
     for target_pixels_block, trial in zip(target_pixels, experiment.trialList):
         for rep in range(trial["weight"]):
             for target_pixel in target_pixels_block:
                 move_mouse_to_target(target_pixel)
-        if trial["post_block_display_results"]:
-            # ascii image of screen for debugging logs
-            sleep(0.5)
-            ascii_screenshot()
-            # press escape to exit results display
-            pyautogui.typewrite(["escape"])
-    results = queue.get()
-    process.join()
-    return results
 
 
-def test_task(experiment_no_results: TrialHandlerExt) -> None:
+def launch_do_task(
+    experiment: TrialHandlerExt, target_pixels: List[List[Tuple[float, float]]]
+) -> threading.Thread:
+    thread = threading.Thread(
+        target=do_task,
+        name="task",
+        args=(
+            experiment,
+            target_pixels,
+        ),
+    )
+    thread.start()
+    return thread
+
+
+def test_task(experiment_no_results: TrialHandlerExt, window: Window) -> None:
     target_pixels = []
     for trial in experiment_no_results.trialList:
         trial["automove_cursor_to_center"] = True
         target_pixels.append(
             [
-                pos_to_pixels(pos)
+                gtu.pos_to_pixels(pos)
                 for pos in points_on_circle(
                     trial["num_targets"],
                     trial["target_distance"],
@@ -96,7 +70,10 @@ def test_task(experiment_no_results: TrialHandlerExt) -> None:
                 )
             ]
         )
-    results = do_task(experiment_no_results, target_pixels)
+    do_task_thread = launch_do_task(experiment_no_results, target_pixels)
+    task = mtptask.MotorTask(experiment_no_results)
+    results = task.run(window)
+    do_task_thread.join()
     # check that we hit all the targets without timing out
     for timestamps in results.data["to_target_timestamps"][0][0]:
         assert (
@@ -104,7 +81,9 @@ def test_task(experiment_no_results: TrialHandlerExt) -> None:
         )
 
 
-def test_task_no_automove_to_center(experiment_no_results: TrialHandlerExt) -> None:
+def test_task_no_automove_to_center(
+    experiment_no_results: TrialHandlerExt, window: Window
+) -> None:
     target_pixels = []
     for trial in experiment_no_results.trialList:
         trial["automove_cursor_to_center"] = False
@@ -115,10 +94,13 @@ def test_task_no_automove_to_center(experiment_no_results: TrialHandlerExt) -> N
             include_centre=False,
         ):
             # after moving to each target need to return mouse to central target
-            tp.append(pos_to_pixels(pos))
-            tp.append(pos_to_pixels((0, 0)))
+            tp.append(gtu.pos_to_pixels(pos))
+            tp.append(gtu.pos_to_pixels((0, 0)))
         target_pixels.append(tp)
-    results = do_task(experiment_no_results, target_pixels)
+    do_task_thread = launch_do_task(experiment_no_results, target_pixels)
+    task = mtptask.MotorTask(experiment_no_results)
+    results = task.run(window)
+    do_task_thread.join()
     # check that we hit all the targets
     for to_target_timestamps, to_center_timestamps in zip(
         results.data["to_target_timestamps"][0][0],

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -34,6 +34,13 @@ def test_default_trial() -> None:
     assert len(trial["target_indices"].split(" ")) == trial["num_targets"]
 
 
+def test_trial_labels() -> None:
+    trial = mtptrial.default_trial()
+    labels = mtptrial.trial_labels()
+    assert len(trial) == len(labels)
+    assert trial.keys() == labels.keys()
+
+
 def test_import_trial() -> None:
     default_trial = mtptrial.default_trial()
     trial_dict = {


### PR DESCRIPTION
add splash screen and metadata
    
- display splash screen with title and instructions before task begins
- add `MotorTaskMetadata`
  - info about experiment, author, date, etc
  - what text to show on splash screen
- add dialog to define this metadata at the start of new experiment setup
- resolves #41
    
also
    
- remove timeout for display_results screen, always wait for Enter keypress
- make keypress behaviour consistent everywhere:
  - Enter closes current screen / continues to next screen
  - Escape exits entire program