### PR TITLE
improve import of existing dicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,4 @@ repos:
       - id: flake8
         args:
           - "--max-line-length=88"
+          - "--ignore=E501,W503"

--- a/src/motor_task_prototype/common.py
+++ b/src/motor_task_prototype/common.py
@@ -1,0 +1,51 @@
+import copy
+import logging
+from typing import Any
+from typing import Dict
+from typing import Type
+from typing import TypeVar
+
+import motor_task_prototype.types as mtptypes
+
+MtpTypedDict = TypeVar(
+    "MtpTypedDict",
+    mtptypes.MotorTaskTrial,
+    mtptypes.MotorTaskMetadata,
+    mtptypes.MotorTaskDisplayOptions,
+)
+
+
+def has_valid_type(var: Any, correct_type: Type) -> bool:
+    if isinstance(var, correct_type):
+        # var has the correct type
+        return True
+    if correct_type in (float, int) and type(var) in (float, int):
+        # int instead of float or vice versa is ok
+        return True
+    return False
+
+
+def import_typed_dict(
+    input_dict: Dict, default_typed_dict: MtpTypedDict
+) -> MtpTypedDict:
+    # start with a valid typed dict with default values
+    output_dict = copy.deepcopy(default_typed_dict)
+    for key, default_value in output_dict.items():
+        if key in input_dict:
+            # import all valid keys from input_dict
+            correct_type = type(default_value)
+            value = input_dict[key]
+            if has_valid_type(value, correct_type):
+                output_dict[key] = correct_type(value)  # type: ignore
+            else:
+                logging.warning(
+                    f"Key '{key}' invalid: expected {correct_type}, got {type(value)} '{value}'"
+                )
+        else:
+            # warn if a key is missing
+            logging.warning(f"Key '{key}' missing, using default '{default_value}'")
+    for key in input_dict:
+        if key not in output_dict:
+            # warn if there are any unknown keys in the input dict
+            logging.warning(f"Ignoring unknown key '{key}'")
+    return output_dict

--- a/src/motor_task_prototype/display.py
+++ b/src/motor_task_prototype/display.py
@@ -1,0 +1,66 @@
+import copy
+from typing import Dict
+from typing import Optional
+
+import motor_task_prototype.common as mtpcommon
+from motor_task_prototype.types import MotorTaskDisplayOptions
+from psychopy import core
+from psychopy.gui import DlgFromDict
+
+
+def default_display_options() -> MotorTaskDisplayOptions:
+    return {
+        "to_target_paths": True,
+        "to_center_paths": False,
+        "targets": True,
+        "central_target": True,
+        "to_target_reaction_time": True,
+        "to_center_reaction_time": False,
+        "to_target_time": True,
+        "to_center_time": False,
+        "to_target_distance": True,
+        "to_center_distance": False,
+        "to_target_rmse": True,
+        "to_center_rmse": False,
+        "averages": True,
+    }
+
+
+def display_options_labels() -> Dict:
+    return {
+        "to_target_paths": "Display cursor paths to target",
+        "to_center_paths": "Display cursor paths back to center",
+        "targets": "Display targets",
+        "central_target": "Display central target",
+        "to_target_reaction_time": "Statistic: reaction time to target",
+        "to_center_reaction_time": "Statistic: reaction time to center",
+        "to_target_time": "Statistic: movement time to target",
+        "to_center_time": "Statistic: movement time to center",
+        "to_target_distance": "Statistic: movement distance to target",
+        "to_center_distance": "Statistic: movement distance to center",
+        "to_target_rmse": "Statistic: RMSE movement to target",
+        "to_center_rmse": "Statistic: RMSE movement to center",
+        "averages": "Also show statistics averaged over all targets",
+    }
+
+
+def get_display_options_from_user(
+    initial_display_options: Optional[MotorTaskDisplayOptions] = None,
+) -> MotorTaskDisplayOptions:
+    if initial_display_options:
+        display_options = copy.deepcopy(initial_display_options)
+    else:
+        display_options = default_display_options()
+    dialog = DlgFromDict(
+        display_options,
+        title="Motor task display options",
+        labels=display_options_labels(),
+        sortKeys=False,
+    )
+    if not dialog.OK:
+        core.quit()
+    return display_options
+
+
+def import_display_options(display_options_dict: dict) -> MotorTaskDisplayOptions:
+    return mtpcommon.import_typed_dict(display_options_dict, default_display_options())

--- a/src/motor_task_prototype/meta.py
+++ b/src/motor_task_prototype/meta.py
@@ -1,30 +1,11 @@
 import copy
-import sys
 from typing import Dict
 from typing import Optional
 
+import motor_task_prototype.common as mtpcommon
+from motor_task_prototype.types import MotorTaskMetadata
 from psychopy import core
 from psychopy.gui import DlgFromDict
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
-MotorTaskMetadata = TypedDict(
-    "MotorTaskMetadata",
-    {
-        "name": str,
-        "subject": str,
-        "date": str,
-        "author": str,
-        "display_title": str,
-        "display_text1": str,
-        "display_text2": str,
-        "display_text3": str,
-        "display_text4": str,
-    },
-)
 
 
 def default_metadata() -> MotorTaskMetadata:
@@ -71,3 +52,7 @@ def get_metadata_from_user(
     if not dialog.OK:
         core.quit()
     return metadata
+
+
+def import_metadata(metadata_dict: dict) -> MotorTaskMetadata:
+    return mtpcommon.import_typed_dict(metadata_dict, default_metadata())

--- a/src/motor_task_prototype/setup.py
+++ b/src/motor_task_prototype/setup.py
@@ -4,13 +4,13 @@ from typing import Optional
 
 import motor_task_prototype as mtp
 import wx
+from motor_task_prototype.display import get_display_options_from_user
 from motor_task_prototype.meta import get_metadata_from_user
 from motor_task_prototype.task import new_experiment_from_dicts
 from motor_task_prototype.task import new_experiment_from_trialhandler
 from motor_task_prototype.trial import describe_trials
 from motor_task_prototype.trial import get_trial_from_user
 from motor_task_prototype.trial import MotorTaskTrial
-from motor_task_prototype.vis import get_display_options_from_user
 from psychopy.data import TrialHandlerExt
 from psychopy.gui import fileOpenDlg
 from psychopy.misc import fromFile

--- a/src/motor_task_prototype/trial.py
+++ b/src/motor_task_prototype/trial.py
@@ -1,43 +1,13 @@
 import copy
-import logging
-import sys
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Union
 
+import motor_task_prototype.common as mtpcommon
 import numpy as np
+from motor_task_prototype.types import MotorTaskTrial
 from psychopy import core
 from psychopy.gui import DlgFromDict
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
-MotorTaskTrial = TypedDict(
-    "MotorTaskTrial",
-    {
-        "weight": int,
-        "num_targets": int,
-        "target_order": Union[str, List],
-        "target_indices": Union[np.ndarray, str],
-        "target_duration": float,
-        "inter_target_duration": float,
-        "target_distance": float,
-        "target_size": float,
-        "central_target_size": float,
-        "play_sound": bool,
-        "automove_cursor_to_center": bool,
-        "show_cursor": bool,
-        "show_cursor_path": bool,
-        "cursor_rotation_degrees": float,
-        "post_trial_delay": float,
-        "post_trial_display_results": bool,
-        "post_block_delay": float,
-        "post_block_display_results": bool,
-    },
-)
 
 
 def describe_trial(trial: MotorTaskTrial) -> str:
@@ -117,18 +87,7 @@ def get_trial_from_user(
 
 
 def import_trial(trial_dict: dict) -> MotorTaskTrial:
-    # start with a default valid trial
-    trial = default_trial()
-    # import all valid keys from input_trial
-    for key in trial:
-        if key in trial_dict:
-            trial[key] = trial_dict[key]  # type: ignore
-        else:
-            logging.warning(f"Key '{key}' missing from trial")
-    for key in trial_dict:
-        if key not in trial:
-            logging.warning(f"Ignoring unknown key '{key}'")
-    return trial
+    return mtpcommon.import_typed_dict(trial_dict, default_trial())
 
 
 def validate_trial(trial: MotorTaskTrial) -> MotorTaskTrial:

--- a/src/motor_task_prototype/types.py
+++ b/src/motor_task_prototype/types.py
@@ -1,0 +1,59 @@
+import sys
+from typing import List
+from typing import Union
+
+import numpy as np
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+
+class MotorTaskTrial(TypedDict):
+    weight: int
+    num_targets: int
+    target_order: Union[str, List]
+    target_indices: Union[np.ndarray, str]
+    target_duration: float
+    inter_target_duration: float
+    target_distance: float
+    target_size: float
+    central_target_size: float
+    play_sound: bool
+    automove_cursor_to_center: bool
+    show_cursor: bool
+    show_cursor_path: bool
+    cursor_rotation_degrees: float
+    post_trial_delay: float
+    post_trial_display_results: bool
+    post_block_delay: float
+    post_block_display_results: bool
+
+
+class MotorTaskDisplayOptions(TypedDict):
+    to_target_paths: bool
+    to_center_paths: bool
+    targets: bool
+    central_target: bool
+    to_target_reaction_time: bool
+    to_center_reaction_time: bool
+    to_target_time: bool
+    to_center_time: bool
+    to_target_distance: bool
+    to_center_distance: bool
+    to_target_rmse: bool
+    to_center_rmse: bool
+    averages: bool
+
+
+class MotorTaskMetadata(TypedDict):
+    name: str
+    subject: str
+    date: str
+    author: str
+    display_title: str
+    display_text1: str
+    display_text2: str
+    display_text3: str
+    display_text4: str

--- a/src/motor_task_prototype/vis.py
+++ b/src/motor_task_prototype/vis.py
@@ -1,17 +1,15 @@
-import copy
-import sys
-from typing import Dict
 from typing import List
 from typing import Optional
 
 import motor_task_prototype.meta as mtpmeta
 import motor_task_prototype.stat as mtpstat
 import numpy as np
+from motor_task_prototype.display import default_display_options
 from motor_task_prototype.geom import points_on_circle
+from motor_task_prototype.types import MotorTaskDisplayOptions
 from psychopy import core
 from psychopy.colors import colors
 from psychopy.data import TrialHandlerExt
-from psychopy.gui import DlgFromDict
 from psychopy.hardware.keyboard import Keyboard
 from psychopy.visual.basevisual import BaseVisualStim
 from psychopy.visual.circle import Circle
@@ -20,85 +18,7 @@ from psychopy.visual.shape import ShapeStim
 from psychopy.visual.textbox2 import TextBox2
 from psychopy.visual.window import Window
 
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
 colors.pop("none")
-
-MotorTaskDisplayOptions = TypedDict(
-    "MotorTaskDisplayOptions",
-    {
-        "to_target_paths": bool,
-        "to_center_paths": bool,
-        "targets": bool,
-        "central_target": bool,
-        "to_target_reaction_time": bool,
-        "to_center_reaction_time": bool,
-        "to_target_time": bool,
-        "to_center_time": bool,
-        "to_target_distance": bool,
-        "to_center_distance": bool,
-        "to_target_rmse": bool,
-        "to_center_rmse": bool,
-        "averages": bool,
-    },
-)
-
-
-def default_display_options() -> MotorTaskDisplayOptions:
-    return {
-        "to_target_paths": True,
-        "to_center_paths": False,
-        "targets": True,
-        "central_target": True,
-        "to_target_reaction_time": True,
-        "to_center_reaction_time": False,
-        "to_target_time": True,
-        "to_center_time": False,
-        "to_target_distance": True,
-        "to_center_distance": False,
-        "to_target_rmse": True,
-        "to_center_rmse": False,
-        "averages": True,
-    }
-
-
-def display_options_labels() -> Dict:
-    return {
-        "to_target_paths": "Display cursor paths to target",
-        "to_center_paths": "Display cursor paths back to center",
-        "targets": "Display targets",
-        "central_target": "Display central target",
-        "to_target_reaction_time": "Statistic: reaction time to target",
-        "to_center_reaction_time": "Statistic: reaction time to center",
-        "to_target_time": "Statistic: movement time to target",
-        "to_center_time": "Statistic: movement time to center",
-        "to_target_distance": "Statistic: movement distance to target",
-        "to_center_distance": "Statistic: movement distance to center",
-        "to_target_rmse": "Statistic: RMSE movement to target",
-        "to_center_rmse": "Statistic: RMSE movement to center",
-        "averages": "Also show statistics averaged over all targets",
-    }
-
-
-def get_display_options_from_user(
-    initial_display_options: Optional[MotorTaskDisplayOptions] = None,
-) -> MotorTaskDisplayOptions:
-    if initial_display_options:
-        display_options = copy.deepcopy(initial_display_options)
-    else:
-        display_options = default_display_options()
-    dialog = DlgFromDict(
-        display_options,
-        title="Motor task display options",
-        labels=display_options_labels(),
-        sortKeys=False,
-    )
-    if not dialog.OK:
-        core.quit()
-    return display_options
 
 
 def make_cursor(window: Window) -> ShapeStim:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,55 @@
+import motor_task_prototype.display as mtpdisplay
+import pytest
+
+
+def test_display_options_labels() -> None:
+    display_options = mtpdisplay.default_display_options()
+    labels = mtpdisplay.display_options_labels()
+    assert len(display_options) == len(labels)
+    assert display_options.keys() == labels.keys()
+
+
+def test_import_display_options(caplog: pytest.LogCaptureFixture) -> None:
+    default_display_options = mtpdisplay.default_display_options()
+    display_options_dict = {
+        "to_target_paths": True,
+        "to_center_paths": "I should be a bool!",
+        "targets": True,
+        "central_target": True,
+        "to_target_reaction_time": True,
+        "to_center_reaction_time": True,
+        "to_target_time": True,
+        "to_center_time": True,
+        "to_target_distance": False,
+        "to_center_distance": False,
+        "to_target_rmse": False,
+        "to_center_rmse": False,
+        "averages": True,
+        "unknown_key1": "ignore me",
+        "unknown_key2": False,
+    }
+    # if any keys are missing or have invalid values, default values are used instead
+    missing_keys = [
+        "to_center_reaction_time",
+        "to_target_rmse",
+        "to_center_rmse",
+    ]
+    for key in missing_keys:
+        display_options_dict.pop(key)
+    invalid_values = ["to_center_paths"]
+    display_options = mtpdisplay.import_display_options(display_options_dict)
+    for key in display_options:
+        if key in missing_keys or key in invalid_values:
+            assert display_options[key] == default_display_options[key]  # type: ignore
+        else:
+            assert display_options[key] == display_options_dict[key]  # type: ignore
+    log_messages = {r.message for r in caplog.records}
+    expected_log_messages = {
+        "Key 'to_center_reaction_time' missing, using default 'False'",
+        "Key 'to_target_rmse' missing, using default 'True'",
+        "Key 'to_center_rmse' missing, using default 'False'",
+        "Key 'to_center_paths' invalid: expected <class 'bool'>, got <class 'str'> 'I should be a bool!'",
+        "Ignoring unknown key 'unknown_key1'",
+        "Ignoring unknown key 'unknown_key2'",
+    }
+    assert log_messages == expected_log_messages

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -11,13 +11,6 @@ from psychopy.data import TrialHandlerExt
 from psychopy.visual.window import Window
 
 
-def test_display_options_labels() -> None:
-    display_options = mtpvis.default_display_options()
-    labels = mtpvis.display_options_labels()
-    assert len(display_options) == len(labels)
-    assert display_options.keys() == labels.keys()
-
-
 def test_make_cursor(window: Window) -> None:
     cursor = mtpvis.make_cursor(window)
     assert np.allclose(cursor.pos, [0, 0])


### PR DESCRIPTION
- internally we use a TypedDict for metadata, trial and vis options for type safety
- when importing one of these from csv or psydat we get a plain dict, which may have missing or invalid keys
- on import we start with a valid TypedDict containing default values
- any keys present in the input dict overwrite the corresponding value
- defaults are used for keys missing from the input dict (and a warning is logged)
- invalid or unknown keys are ignored (and a warning is logged)
- refactor
  - add types.py with TypedDict definitions
  - add common.py with `import_typed_dict` utility function
  - add display.py to deal with display options separately from vis.py
