### PR TITLE
make GUI vis tests more robust

### DIFF
--- a/src/motor_task_prototype/vis.py
+++ b/src/motor_task_prototype/vis.py
@@ -276,6 +276,7 @@ def display_results(
             letterHeight=0.03,
         )
     )
+    kb.clearEvents()
     while True:
         if not draw_and_flip(win, drawables, kb):
             if close_window_when_done:
@@ -335,6 +336,7 @@ def splash_screen(
             letterHeight=0.03,
         )
     )
+    kb.clearEvents()
     while True:
         if not draw_and_flip(win, drawables, kb):
             if close_window_when_done:


### PR DESCRIPTION
- after display target function returns
  - flip window to make it all grey
- instead of pressing enter once in separate thread to make target return
  - keep pressing enter until screen is all grey
- should resolve flakiness on windows CI where tests hang after enter key event got lost and target never returns
