### PR TITLE
add first qt gui tests for DisplayOptionsWidget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} :: Python ${{ matrix.python-version }}"
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "windows-latest"]
         python-version: ["3.8", "3.9"]
@@ -31,8 +32,8 @@ jobs:
       - name: Linux setup
         if: runner.os == 'Linux'
         run: |
-          # various psychopy system dependencies
-          sudo apt-get update -yy && sudo apt-get install -yy libasound2-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev libsndfile1-dev libportmidi-dev liblo-dev libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0 freeglut3-dev scrot libnotify-dev pandoc
+          # various psychopy & qt system dependencies
+          sudo apt-get update -yy && sudo apt-get install -yy libasound2-dev portaudio19-dev libpulse-dev libusb-1.0-0-dev libsndfile1-dev libportmidi-dev liblo-dev libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0 freeglut3-dev scrot libnotify-dev pandoc libxcb-glx0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xinput0 libxcb-xkb1 libxcb1 libxkbcommon-x11-0 libxkbcommon0 libxrender1
           # install pre-built ubuntu/gtk3 wxPython wheel
           pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${{ matrix.os }}/ wxPython
           # enable colours in logs
@@ -43,6 +44,8 @@ jobs:
           # start an Xvfb server for GUI tests
           nohup Xvfb :99 -screen 0 1024x768x24 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
+          # see Qt debug output when loading plugins
+          echo "QT_DEBUG_PLUGINS=1" >> $GITHUB_ENV
       - run: pip install -e .[tests,docs] --verbose
       - run: python -m pytest --cov=motor_task_prototype --cov-report=xml -v -s
       - name: Build documentation

--- a/src/motor_task_prototype/display_widget.py
+++ b/src/motor_task_prototype/display_widget.py
@@ -1,5 +1,6 @@
 from typing import Callable
 from typing import Dict
+from typing import Optional
 
 from motor_task_prototype.display import default_display_options
 from motor_task_prototype.display import display_options_labels
@@ -12,14 +13,14 @@ class DisplayOptionsWidget(QtWidgets.QWidget):
     widgets: Dict[str, QtWidgets.QCheckBox] = {}
     unsaved_changes: bool = False
 
-    def update_value_callback(self, key: str) -> Callable[[bool], None]:
-        def update_value(value: bool) -> None:
+    def _update_value_callback(self, key: str) -> Callable[[bool], None]:
+        def _update_value(value: bool) -> None:
             self.options[key] = value  # type: ignore
             self.unsaved_changes = True
 
-        return update_value
+        return _update_value
 
-    def __init__(self, parent: QtWidgets.QWidget):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent)
         outer_layout = QtWidgets.QVBoxLayout()
         group_box = QtWidgets.QGroupBox("Display Options")
@@ -30,7 +31,7 @@ class DisplayOptionsWidget(QtWidgets.QWidget):
         for row_index, key in enumerate(default_display_options().keys()):
             checkbox = QtWidgets.QCheckBox(f"{labels[key]}", self)
             inner_layout.addWidget(checkbox)
-            checkbox.stateChanged.connect(self.update_value_callback(key))
+            checkbox.clicked.connect(self._update_value_callback(key))
             self.widgets[key] = checkbox
         self.setLayout(outer_layout)
         self.unsaved_changes = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from motor_task_prototype.meta import default_metadata
 from motor_task_prototype.trial import default_trial
 from motor_task_prototype.vis import default_display_options
 from psychopy.data import TrialHandlerExt
+from psychopy.gui.qtgui import ensureQtApp
 from psychopy.visual.window import Window
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
@@ -23,6 +24,13 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 # session scope means it is only called once
 # so this fixture runs once before any tests
 def tests_init() -> None:
+    # opencv-python installs its own qt version and sets env vars accordingly
+    # we remove these to avoid pyqt picking up their XCB QPA plugin & crashing
+    for k, v in os.environ.items():
+        if k.startswith("QT_") and "cv2" in v:
+            del os.environ[k]
+    # ensure psychopy has initialized the qt app
+    ensureQtApp()
     # work around for PsychHID-WARNING about X11 not being initialized on linux
     if sys.platform == "linux":
         import ctypes

--- a/tests/test_display_widget.py
+++ b/tests/test_display_widget.py
@@ -1,0 +1,39 @@
+from typing import Dict
+
+import motor_task_prototype.display as mtpdisplay
+from motor_task_prototype.display_widget import DisplayOptionsWidget
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt
+from PyQt5.QtTest import QTest
+
+
+def _get_check_boxes(
+    display_options_widget: DisplayOptionsWidget,
+) -> Dict[str, QtWidgets.QCheckBox]:
+    check_boxes = {}
+    labels = {v: k for k, v in mtpdisplay.display_options_labels().items()}
+    for check_box in display_options_widget.findChildren(QtWidgets.QCheckBox):
+        check_boxes[labels[check_box.text()]] = check_box
+    return check_boxes
+
+
+def test_display_options_widget() -> None:
+    widget = DisplayOptionsWidget(None)
+    # initially has default display options
+    assert widget.get_display_options() == mtpdisplay.default_display_options()
+    # set all to false
+    all_false = mtpdisplay.default_display_options()
+    for key in all_false:
+        all_false[key] = False  # type: ignore
+    widget.set_display_options(all_false)
+    assert widget.get_display_options() == all_false
+    # modify options by clicking on each check box in turn
+    for key, check_box in _get_check_boxes(widget).items():
+        assert widget.get_display_options()[key] is False  # type: ignore
+        QTest.mouseClick(check_box, Qt.MouseButton.LeftButton)
+        assert widget.get_display_options()[key] is True  # type: ignore
+        QTest.mouseClick(check_box, Qt.MouseButton.LeftButton)
+        assert widget.get_display_options()[key] is False  # type: ignore
+    # check that all values have the correct type
+    for value in widget.get_display_options().values():
+        assert type(value) is bool


### PR DESCRIPTION
- add workaround for qt xcb plugin crash caused by opencv-python env vars
- use `clicked` signal that gives a bool for the checked state of the checkbox instead of `stateChanged`
