### PR TITLE
remove np.typing imports and NDArray use

### DIFF
--- a/src/motor_task_prototype/geom.py
+++ b/src/motor_task_prototype/geom.py
@@ -1,21 +1,20 @@
 from typing import Tuple
 
 import numpy as np
-import numpy.typing as npt
 
 """
 An array of `n_points` equidistantly spaced angles in radians
 """
 
 
-def equidistant_angles(n_points: int) -> npt.NDArray[np.float64]:
+def equidistant_angles(n_points: int) -> np.ndarray:
     max_angle = 2.0 * np.pi * (n_points - 1.0) / n_points
     return np.linspace(0, max_angle, n_points)
 
 
 def points_on_circle(
     n_points: int, radius: float, include_centre: bool = False
-) -> npt.NDArray[np.float64]:
+) -> np.ndarray:
     points = [
         [radius * np.sin(angle), radius * np.cos(angle)]
         for angle in equidistant_angles(n_points)

--- a/src/motor_task_prototype/stat.py
+++ b/src/motor_task_prototype/stat.py
@@ -2,21 +2,20 @@ from typing import List
 from typing import Tuple
 
 import numpy as np
-import numpy.typing as npt
 from psychopy.data import TrialHandlerExt
 from psychopy.event import xydist
 
 
 class MotorTaskStats:
     # 2d arrays of [trial_index][target_index]
-    to_target_reaction_times: npt.NDArray[np.float64]
-    to_center_reaction_times: npt.NDArray[np.float64]
-    to_target_times: npt.NDArray[np.float64]
-    to_center_times: npt.NDArray[np.float64]
-    to_target_distances: npt.NDArray[np.float64]
-    to_center_distances: npt.NDArray[np.float64]
-    to_target_rmses: npt.NDArray[np.float64]
-    to_center_rmses: npt.NDArray[np.float64]
+    to_target_reaction_times: np.ndarray
+    to_center_reaction_times: np.ndarray
+    to_target_times: np.ndarray
+    to_center_times: np.ndarray
+    to_target_distances: np.ndarray
+    to_center_distances: np.ndarray
+    to_target_rmses: np.ndarray
+    to_center_rmses: np.ndarray
 
     def __init__(self, results: TrialHandlerExt, trials: List[int]):
         all_to_target_reaction_times = []

--- a/src/motor_task_prototype/types.py
+++ b/src/motor_task_prototype/types.py
@@ -3,7 +3,6 @@ from typing import List
 from typing import Union
 
 import numpy as np
-import numpy.typing as npt
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -15,7 +14,7 @@ class MotorTaskTrial(TypedDict):
     weight: int
     num_targets: int
     target_order: Union[str, List]
-    target_indices: Union[npt.NDArray[np.uint64], str]
+    target_indices: Union[np.ndarray, str]
     target_duration: float
     inter_target_duration: float
     target_distance: float

--- a/src/motor_task_prototype/vis.py
+++ b/src/motor_task_prototype/vis.py
@@ -4,7 +4,6 @@ from typing import Optional
 import motor_task_prototype.meta as mtpmeta
 import motor_task_prototype.stat as mtpstat
 import numpy as np
-import numpy.typing as npt
 from motor_task_prototype.display import default_display_options
 from motor_task_prototype.geom import points_on_circle
 from motor_task_prototype.types import MotorTaskDisplayOptions
@@ -88,7 +87,7 @@ def draw_and_flip(
 
 
 def make_txt(
-    name: str, units: str, stat: npt.NDArray[np.float64], index: Optional[int] = None
+    name: str, units: str, stat: np.ndarray, index: Optional[int] = None
 ) -> str:
     if stat.shape[-1] == 0:
         # no data available for this statistic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import sys
 from typing import Tuple
 
 import numpy as np
-import numpy.typing as npt
 import pyautogui
 import pytest
 from motor_task_prototype.experiment import new_experiment_from_dicts
@@ -63,12 +62,12 @@ def noise(scale: float = 0.01) -> float:
 
 
 def make_mouse_positions(
-    pos: Tuple[float, float], time_points: npt.NDArray[np.float64]
-) -> npt.NDArray[np.float64]:
+    pos: Tuple[float, float], time_points: np.ndarray
+) -> np.ndarray:
     return np.array([(pos[0] * t + noise(), pos[1] * t + noise()) for t in time_points])
 
 
-def make_timestamps(n_min: int = 8, n_max: int = 20) -> npt.NDArray[np.float64]:
+def make_timestamps(n_min: int = 8, n_max: int = 20) -> np.ndarray:
     return np.linspace(0.0, 1.0, np.random.randint(n_min, n_max))
 
 


### PR DESCRIPTION
- NDArray requires numpy >= 1.21 and provides minimal improvement over plain ndarray
- resolves #96
