### PR TITLE
add `win` and `win_type` options everywhere

### DIFF
--- a/src/motor_task_prototype/__main__.py
+++ b/src/motor_task_prototype/__main__.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import click
 from motor_task_prototype.gui import MotorTaskGui
@@ -7,15 +8,21 @@ from PyQt5 import QtWidgets
 
 
 @click.command()
+@click.option(
+    "--win-type",
+    type=click.Choice(["pyglet", "glfw"], case_sensitive=False),
+    required=False,
+    default="pyglet",
+)
 @click.argument("filename", required=False)
-def main(filename: str) -> None:
+def main(filename: Optional[str], win_type: str) -> None:
     logging.basicConfig(
         format="%(levelname)s %(module)s.%(funcName)s.%(lineno)d :: %(message)s"
     )
     ensureQtApp()
     app = QtWidgets.QApplication.instance()
     assert app is not None
-    gui = MotorTaskGui(filename)
+    gui = MotorTaskGui(filename=filename, win_type=win_type)
     gui.show()
     app.exec()
 

--- a/src/motor_task_prototype/meta_widget.py
+++ b/src/motor_task_prototype/meta_widget.py
@@ -5,12 +5,15 @@ from typing import Optional
 import motor_task_prototype.meta as mtpmeta
 import motor_task_prototype.vis as mtpvis
 from motor_task_prototype.types import MotorTaskMetadata
+from psychopy.visual.window import Window
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import Qt
 
 
 class MetadataWidget(QtWidgets.QWidget):
-    unsaved_changes: bool = False
+    unsaved_changes: bool
+    _win: Optional[Window]
+    _win_type: str
     _meta: MotorTaskMetadata = mtpmeta.empty_metadata()
     _widgets: Dict[str, QtWidgets.QLineEdit] = {}
 
@@ -21,8 +24,15 @@ class MetadataWidget(QtWidgets.QWidget):
 
         return _update_value
 
-    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QtWidgets.QWidget] = None,
+        win: Optional[Window] = None,
+        win_type: str = "pyglet",
+    ):
         super().__init__(parent)
+        self._win = win
+        self._win_type = win_type
         group_box = QtWidgets.QGroupBox("Metadata")
         outer_layout = QtWidgets.QVBoxLayout()
         outer_layout.addWidget(group_box)
@@ -41,14 +51,14 @@ class MetadataWidget(QtWidgets.QWidget):
             line_edit.textEdited.connect(self._update_value_callback(key))
             self._widgets[key] = line_edit
         inner_layout.addWidget(fields)
-        btn_preview_metadata = QtWidgets.QPushButton("Preview Splash Screen")
-        btn_preview_metadata.clicked.connect(self._btn_preview_metadata_clicked)
-        inner_layout.addWidget(btn_preview_metadata)
+        self._btn_preview_metadata = QtWidgets.QPushButton("Preview Splash Screen")
+        self._btn_preview_metadata.clicked.connect(self._btn_preview_metadata_clicked)
+        inner_layout.addWidget(self._btn_preview_metadata)
         self.setLayout(outer_layout)
         self.unsaved_changes = False
 
     def _btn_preview_metadata_clicked(self) -> None:
-        mtpvis.splash_screen(self._meta)
+        mtpvis.splash_screen(self._meta, win=self._win, win_type=self._win_type)
 
     def set_metadata(self, metadata: MotorTaskMetadata) -> None:
         self._meta = metadata

--- a/src/motor_task_prototype/results_widget.py
+++ b/src/motor_task_prototype/results_widget.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from motor_task_prototype.vis import display_results
 from psychopy.data import TrialHandlerExt
+from psychopy.visual.window import Window
 from PyQt5 import QtWidgets
 
 
@@ -13,9 +14,18 @@ class ResultsWidget(QtWidgets.QWidget):
     _experiment: Optional[TrialHandlerExt] = None
     _condition_to_trials: DefaultDict[int, List[int]] = defaultdict(list)
     _trial_to_condition: Dict[int, int] = dict()
+    _win: Optional[Window]
+    _win_type: str
 
-    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QtWidgets.QWidget] = None,
+        win: Optional[Window] = None,
+        win_type: str = "pyglet",
+    ):
         super().__init__(parent)
+        self._win = win
+        self._win_type = win_type
         outer_layout = QtWidgets.QVBoxLayout()
         group_box = QtWidgets.QGroupBox("Results")
         outer_layout.addWidget(group_box)
@@ -46,14 +56,19 @@ class ResultsWidget(QtWidgets.QWidget):
         row = self._list_trials.currentRow()
         if not self._is_valid(row):
             return
-        display_results(self._experiment, [row])
+        display_results(self._experiment, [row], win=self._win, win_type=self._win_type)
 
     def _btn_display_condition_clicked(self) -> None:
         row = self._list_trials.currentRow()
         if not self._is_valid(row):
             return
         condition = self._trial_to_condition[row]
-        display_results(self._experiment, self._condition_to_trials[condition])
+        display_results(
+            self._experiment,
+            self._condition_to_trials[condition],
+            win=self._win,
+            win_type=self._win_type,
+        )
 
     def clear_results(self) -> None:
         self._experiment = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def window() -> Window:
     window.close()
 
 
-def noise(scale: float = 0.01) -> float:
+def noise(scale: float = 0.02) -> float:
     return scale * (np.random.random_sample() - 0.1)
 
 

--- a/tests/helpers/gui_test_utils.py
+++ b/tests/helpers/gui_test_utils.py
@@ -6,6 +6,7 @@ from typing import Callable
 from typing import Tuple
 
 import ascii_magic
+from psychopy.visual.window import Window
 
 if sys.platform.startswith("win"):
     # use alternative library to generate keyboard events on windows
@@ -109,7 +110,9 @@ def get_screenshot_when_ready(
 
 
 # call target with args, get screenshot when ready, press Enter to close screen
-def call_target_and_get_screenshot(target: Callable, args: Tuple) -> np.ndarray:
+def call_target_and_get_screenshot(
+    target: Callable, args: Tuple, win: Window
+) -> np.ndarray:
     screenshot_queue: queue.Queue = queue.Queue()
     screenshot_before = pyautogui.screenshot()
     screenshot_thread = threading.Thread(
@@ -120,7 +123,7 @@ def call_target_and_get_screenshot(target: Callable, args: Tuple) -> np.ndarray:
     screenshot_thread.start()
     target(*args)
     # flip window when finished to make screen all-grey
-    args[-1].flip()
+    win.flip()
     screenshot_thread.join()
     return screenshot_queue.get()
 

--- a/tests/test_meta_widget.py
+++ b/tests/test_meta_widget.py
@@ -1,18 +1,43 @@
+import gui_test_utils as gtu
 import motor_task_prototype.meta as mtpmeta
 from motor_task_prototype.meta_widget import MetadataWidget
+from psychopy.visual.window import Window
 from PyQt5 import QtWidgets
+from PyQt5.QtCore import Qt
 from PyQt5.QtTest import QTest
 
 
-def test_metadata_widget() -> None:
-    widget = MetadataWidget(None)
+def test_metadata_widget(window: Window) -> None:
+    widget = MetadataWidget(parent=None, win=window)
     # initially has empty metadata
     assert widget.get_metadata() == mtpmeta.empty_metadata()
     assert widget.unsaved_changes is False
+    screenshot = gtu.call_target_and_get_screenshot(
+        QTest.mouseClick,
+        (widget._btn_preview_metadata, Qt.MouseButton.LeftButton),
+        window,
+    )
+    # all pixels grey except for blue continue text
+    empty_grey_pixel_fraction = gtu.pixel_color_fraction(screenshot, (128, 128, 128))
+    assert 0.990 < empty_grey_pixel_fraction < 0.999
+    # no other text so no black pixels
+    assert gtu.pixel_color_fraction(screenshot, (0, 0, 0)) == 0.000
     # set all to defaults
     widget.set_metadata(mtpmeta.default_metadata())
     assert widget.get_metadata() == mtpmeta.default_metadata()
     assert widget.unsaved_changes is False
+    screenshot = gtu.call_target_and_get_screenshot(
+        QTest.mouseClick,
+        (widget._btn_preview_metadata, Qt.MouseButton.LeftButton),
+        window,
+    )
+    # less grey pixels since we now have black text
+    assert (
+        gtu.pixel_color_fraction(screenshot, (128, 128, 128))
+        < empty_grey_pixel_fraction
+    )
+    # a couple percent of black pixels due to black text
+    assert 0.005 <= gtu.pixel_color_fraction(screenshot, (0, 0, 0)) <= 0.050
     # reset to empty, then type in each line edit
     widget.set_metadata(mtpmeta.empty_metadata())
     assert widget.unsaved_changes is False

--- a/tests/test_results_widget.py
+++ b/tests/test_results_widget.py
@@ -1,32 +1,67 @@
+import gui_test_utils as gtu
 from motor_task_prototype.results_widget import ResultsWidget
 from psychopy.data import TrialHandlerExt
+from psychopy.visual.window import Window
 from PyQt5.QtCore import Qt
 from PyQt5.QtTest import QTest
 
 
-def test_results_widget(
-    experiment_no_results: TrialHandlerExt, experiment_with_results: TrialHandlerExt
-) -> None:
+def test_results_widget_no_experiment() -> None:
     widget = ResultsWidget(None)
     # initially empty
     assert widget.have_results() is False
     assert widget._list_trials.count() == 0
     assert widget._btn_display_trial.isEnabled() is False
     assert widget._btn_display_condition.isEnabled() is False
+
+
+def test_results_widget_experiment_no_results(
+    experiment_no_results: TrialHandlerExt,
+) -> None:
+    widget = ResultsWidget(None)
     # assign experiment without results
     widget.set_results(experiment_no_results)
     assert widget.have_results() is False
     assert widget._list_trials.count() == 0
     assert widget._btn_display_trial.isEnabled() is False
     assert widget._btn_display_condition.isEnabled() is False
+
+
+def test_results_widget_experiment_with_results(
+    experiment_with_results: TrialHandlerExt, window: Window
+) -> None:
+    widget = ResultsWidget(parent=None, win=window)
     # assign experiment with results
     widget.set_results(experiment_with_results)
     n_trials = 4
     assert widget.have_results() is True
     assert widget._list_trials.count() == n_trials
+    # select first row
     for _ in range(n_trials):
         QTest.keyClick(widget._list_trials, Qt.Key_Up)
     assert widget._list_trials.currentRow() == 0
+    # display trial results
+    screenshot = gtu.call_target_and_get_screenshot(
+        QTest.mouseClick,
+        (widget._btn_display_trial, Qt.MouseButton.LeftButton),
+        window,
+    )
+    # most pixels grey
+    trial_grey_frac = gtu.pixel_color_fraction(screenshot, (128, 128, 128))
+    assert 0.900 < trial_grey_frac < 0.999
+    # some off-white pixels
+    assert 0.001 <= gtu.pixel_color_fraction(screenshot, (240, 248, 255)) <= 0.050
+    # display condition results from 3 trials
+    screenshot = gtu.call_target_and_get_screenshot(
+        QTest.mouseClick,
+        (widget._btn_display_condition, Qt.MouseButton.LeftButton),
+        window,
+    )
+    # less grey pixels than a single trial
+    assert gtu.pixel_color_fraction(screenshot, (128, 128, 128)) < trial_grey_frac
+    # some off-white pixels
+    assert 0.001 <= gtu.pixel_color_fraction(screenshot, (240, 248, 255)) <= 0.050
+    # select each row in turn
     for row in range(n_trials):
         assert widget._list_trials.currentRow() == row
         assert widget._btn_display_trial.isEnabled() is True

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -90,7 +90,7 @@ def test_update_target_colors(window: Window, n_targets: int) -> None:
 def test_splash_screen_defaults(window: Window) -> None:
     metadata = mtpmeta.default_metadata()
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.splash_screen, (metadata, window)
+        mtpvis.splash_screen, (metadata, window), window
     )
     # most pixels grey except for black main text and blue continue text
     assert 0.900 < gtu.pixel_color_fraction(screenshot, (128, 128, 128)) < 0.999
@@ -121,7 +121,7 @@ def test_display_results_nothing(
     # trial data without auto-move to center
     trial_indices = [0, 1, 2]
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.display_results, (experiment_with_results, trial_indices, window)
+        mtpvis.display_results, (experiment_with_results, trial_indices, window), window
     )
     # all pixels grey except for blue continue text
     assert 0.990 < gtu.pixel_color_fraction(screenshot, (128, 128, 128)) < 0.999
@@ -130,7 +130,7 @@ def test_display_results_nothing(
     # trial data with auto-move to center
     trial_indices = [3]
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.display_results, (experiment_with_results, trial_indices, window)
+        mtpvis.display_results, (experiment_with_results, trial_indices, window), window
     )
     # all pixels grey except for blue continue text
     assert 0.990 < gtu.pixel_color_fraction(screenshot, (128, 128, 128)) < 0.999
@@ -159,7 +159,7 @@ def test_display_results_everything(
     # trial data without auto-move to center
     trial_indices = [0, 1, 2]
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.display_results, (experiment_with_results, trial_indices, window)
+        mtpvis.display_results, (experiment_with_results, trial_indices, window), window
     )
     # less grey: lots of other colors for targets, paths and stats
     grey_pixels = gtu.pixel_color_fraction(screenshot, (128, 128, 128))
@@ -170,7 +170,7 @@ def test_display_results_everything(
     # trial data with auto-move to center
     trial_indices = [3]
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.display_results, (experiment_with_results, trial_indices, window)
+        mtpvis.display_results, (experiment_with_results, trial_indices, window), window
     )
-    # more grey since less paths and stats to display
+    # more grey since there are fewer paths and stats to display
     assert gtu.pixel_color_fraction(screenshot, (128, 128, 128)) > grey_pixels


### PR DESCRIPTION
- add optional `--win-type` command line option for app
- add optional `win` and `win_type` parameters for widgets
- defaults are "pyglet" for `win_type` and `None` for `win`
- add tests of Window output for meta and results widgets
