### PR TITLE
add Experiment class

### DIFF
--- a/benchmarks/profile_task.py
+++ b/benchmarks/profile_task.py
@@ -1,20 +1,13 @@
 import cProfile
 
-from motor_task_prototype.display import default_display_options
-from motor_task_prototype.experiment import new_experiment_from_dicts
-from motor_task_prototype.meta import default_metadata
+from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.task import run_task
-from motor_task_prototype.trial import default_trial
 from psychopy import core
 
-
-trial = default_trial()
-trial["weight"] = 1
-trial["inter_target_duration"] = 0
-trial["post_block_display_results"] = False
-experiment = new_experiment_from_dicts(
-    [trial], default_display_options(), default_metadata()
-)
+experiment = MotorTaskExperiment()
+experiment.trial_list[0]["weight"] = 1
+experiment.trial_list[0]["inter_target_duration"] = 0
+experiment.trial_list[0]["post_block_display_results"] = False
 with cProfile.Profile() as pr:
     results = run_task(experiment=experiment)
 pr.dump_stats("profile_task.prof")

--- a/src/motor_task_prototype/__init__.py
+++ b/src/motor_task_prototype/__init__.py
@@ -2,4 +2,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.5.5"
+__version__ = "0.6.0"

--- a/src/motor_task_prototype/display_widget.py
+++ b/src/motor_task_prototype/display_widget.py
@@ -2,45 +2,55 @@ from typing import Callable
 from typing import Dict
 from typing import Optional
 
-from motor_task_prototype.display import default_display_options
 from motor_task_prototype.display import display_options_labels
-from motor_task_prototype.types import MotorTaskDisplayOptions
+from motor_task_prototype.experiment import MotorTaskExperiment
+from psychopy.visual.window import Window
+from PyQt5 import QtCore
 from PyQt5 import QtWidgets
 
 
 class DisplayOptionsWidget(QtWidgets.QWidget):
-    unsaved_changes: bool = False
-    _options: MotorTaskDisplayOptions = default_display_options()
-    _widgets: Dict[str, QtWidgets.QCheckBox] = {}
+    experiment_modified = QtCore.pyqtSignal()
 
-    def _update_value_callback(self, key: str) -> Callable[[bool], None]:
-        def _update_value(value: bool) -> None:
-            self._options[key] = value  # type: ignore
-            self.unsaved_changes = True
-
-        return _update_value
-
-    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
+    def __init__(
+        self,
+        parent: Optional[QtWidgets.QWidget] = None,
+        win: Optional[Window] = None,
+        win_type: str = "pyglet",
+    ):
         super().__init__(parent)
+        self._win = win
+        self._win_type = win_type
+        self._experiment: MotorTaskExperiment = MotorTaskExperiment()
+        self._widgets: Dict[str, QtWidgets.QCheckBox] = {}
+
         outer_layout = QtWidgets.QVBoxLayout()
         group_box = QtWidgets.QGroupBox("Display Options")
         outer_layout.addWidget(group_box)
         inner_layout = QtWidgets.QVBoxLayout()
         group_box.setLayout(inner_layout)
         labels = display_options_labels()
-        for row_index, key in enumerate(default_display_options().keys()):
+        for row_index, key in enumerate(labels.keys()):
             checkbox = QtWidgets.QCheckBox(f"{labels[key]}", self)
             inner_layout.addWidget(checkbox)
             checkbox.clicked.connect(self._update_value_callback(key))
             self._widgets[key] = checkbox
         self.setLayout(outer_layout)
-        self.unsaved_changes = False
 
-    def set_display_options(self, display_options: MotorTaskDisplayOptions) -> None:
-        self._options = display_options
+    def _update_value_callback(self, key: str) -> Callable[[bool], None]:
+        def _update_value(value: bool) -> None:
+            self._experiment.display_options[key] = value  # type: ignore
+            self._experiment.has_unsaved_changes = True
+            self.experiment_modified.emit()
+
+        return _update_value
+
+    @property
+    def experiment(self) -> MotorTaskExperiment:
+        return self._experiment
+
+    @experiment.setter
+    def experiment(self, experiment: MotorTaskExperiment) -> None:
+        self._experiment = experiment
         for key, widget in self._widgets.items():
-            widget.setChecked(self._options[key])  # type: ignore
-        self.unsaved_changes = False
-
-    def get_display_options(self) -> MotorTaskDisplayOptions:
-        return self._options
+            widget.setChecked(self._experiment.display_options[key])  # type: ignore

--- a/src/motor_task_prototype/results_widget.py
+++ b/src/motor_task_prototype/results_widget.py
@@ -4,19 +4,13 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.vis import display_results
-from psychopy.data import TrialHandlerExt
 from psychopy.visual.window import Window
 from PyQt5 import QtWidgets
 
 
 class ResultsWidget(QtWidgets.QWidget):
-    _experiment: Optional[TrialHandlerExt] = None
-    _condition_to_trials: DefaultDict[int, List[int]] = defaultdict(list)
-    _trial_to_condition: Dict[int, int] = dict()
-    _win: Optional[Window]
-    _win_type: str
-
     def __init__(
         self,
         parent: Optional[QtWidgets.QWidget] = None,
@@ -26,6 +20,10 @@ class ResultsWidget(QtWidgets.QWidget):
         super().__init__(parent)
         self._win = win
         self._win_type = win_type
+        self._experiment = MotorTaskExperiment()
+        self._condition_to_trials: DefaultDict[int, List[int]] = defaultdict(list)
+        self._trial_to_condition: Dict[int, int] = dict()
+
         outer_layout = QtWidgets.QVBoxLayout()
         group_box = QtWidgets.QGroupBox("Results")
         outer_layout.addWidget(group_box)
@@ -45,7 +43,10 @@ class ResultsWidget(QtWidgets.QWidget):
         self._row_changed()
 
     def _is_valid(self, row: int) -> bool:
-        return self.have_results() and 0 <= row < self._list_trials.count()
+        return (
+            self.experiment.trial_handler_with_results is not None
+            and 0 <= row < self._list_trials.count()
+        )
 
     def _row_changed(self) -> None:
         valid = self._is_valid(self._list_trials.currentRow())
@@ -56,7 +57,13 @@ class ResultsWidget(QtWidgets.QWidget):
         row = self._list_trials.currentRow()
         if not self._is_valid(row):
             return
-        display_results(self._experiment, [row], win=self._win, win_type=self._win_type)
+        display_results(
+            self._experiment.trial_handler_with_results,
+            self._experiment.display_options,
+            [row],
+            win=self._win,
+            win_type=self._win_type,
+        )
 
     def _btn_display_condition_clicked(self) -> None:
         row = self._list_trials.currentRow()
@@ -64,32 +71,32 @@ class ResultsWidget(QtWidgets.QWidget):
             return
         condition = self._trial_to_condition[row]
         display_results(
-            self._experiment,
+            self._experiment.trial_handler_with_results,
+            self._experiment.display_options,
             self._condition_to_trials[condition],
             win=self._win,
             win_type=self._win_type,
         )
 
-    def clear_results(self) -> None:
-        self._experiment = None
+    @property
+    def experiment(self) -> MotorTaskExperiment:
+        return self._experiment
+
+    @experiment.setter
+    def experiment(self, experiment: MotorTaskExperiment) -> None:
         self._trial_to_condition.clear()
         self._condition_to_trials.clear()
         self._list_trials.clear()
-
-    def have_results(self) -> bool:
-        return self._experiment is not None and self._experiment.finished
-
-    def set_results(self, experiment: TrialHandlerExt) -> None:
-        self.clear_results()
         self._experiment = experiment
-        # assume 1 repetition of experiment
-        i_rep = 0
-        self._list_trials.clear()
-        if experiment.finished is False:
+        if experiment.trial_handler_with_results is None:
             return
-        for trial_index, condition_index in enumerate(experiment.sequenceIndices):
+        # assume 1 repetition of experiment
+        rep_index = 0
+        for trial_index, condition_index in enumerate(
+            experiment.trial_handler_with_results.sequenceIndices
+        ):
             self._list_trials.addItem(
-                f"Trial {trial_index} [Condition {condition_index[i_rep]}]"
+                f"Trial {trial_index} [Condition {condition_index[rep_index]}]"
             )
-            self._condition_to_trials[condition_index[i_rep]].append(trial_index)
-            self._trial_to_condition[trial_index] = condition_index[i_rep]
+            self._condition_to_trials[condition_index[rep_index]].append(trial_index)
+            self._trial_to_condition[trial_index] = condition_index[rep_index]

--- a/src/motor_task_prototype/stat.py
+++ b/src/motor_task_prototype/stat.py
@@ -7,25 +7,18 @@ from psychopy.event import xydist
 
 
 class MotorTaskStats:
-    # 2d arrays of [trial_index][target_index]
-    to_target_reaction_times: np.ndarray
-    to_center_reaction_times: np.ndarray
-    to_target_times: np.ndarray
-    to_center_times: np.ndarray
-    to_target_distances: np.ndarray
-    to_center_distances: np.ndarray
-    to_target_rmses: np.ndarray
-    to_center_rmses: np.ndarray
-
-    def __init__(self, results: TrialHandlerExt, trials: List[int]):
-        all_to_target_reaction_times = []
-        all_to_target_times = []
-        all_to_target_distances = []
-        all_to_target_rmses = []
-        all_to_center_reaction_times = []
-        all_to_center_times = []
-        all_to_center_distances = []
-        all_to_center_rmses = []
+    def __init__(self, trial_handler: TrialHandlerExt, trials: List[int]):
+        all_to_target_reaction_times: List[List[float]] = []
+        all_to_target_times: List[List[float]] = []
+        all_to_target_distances: List[List[float]] = []
+        all_to_target_rmses: List[List[float]] = []
+        all_to_center_reaction_times: List[List[float]] = []
+        all_to_center_times: List[List[float]] = []
+        all_to_center_distances: List[List[float]] = []
+        all_to_center_rmses: List[List[float]] = []
+        if trial_handler is None:
+            return
+        data = trial_handler.data
         # for now assume the experiment is only repeated once
         i_repeat = 0
         for i_trial in trials:
@@ -33,10 +26,10 @@ class MotorTaskStats:
             to_target_times = []
             to_target_distances = []
             to_target_rmses = []
-            targets = results.data["target_pos"][i_trial][i_repeat]
+            targets = data["target_pos"][i_trial][i_repeat]
             for to_target_timestamps, to_target_mouse_positions, target_pos in zip(
-                results.data["to_target_timestamps"][i_trial][i_repeat],
-                results.data["to_target_mouse_positions"][i_trial][i_repeat],
+                data["to_target_timestamps"][i_trial][i_repeat],
+                data["to_target_mouse_positions"][i_trial][i_repeat],
                 targets,
             ):
                 to_target_reaction_time, to_target_time = reaction_movement_times(
@@ -56,8 +49,8 @@ class MotorTaskStats:
             to_center_rmses = []
             central_target = (0.0, 0.0)
             for to_center_timestamps, to_center_mouse_positions in zip(
-                results.data["to_center_timestamps"][i_trial][i_repeat],
-                results.data["to_center_mouse_positions"][i_trial][i_repeat],
+                data["to_center_timestamps"][i_trial][i_repeat],
+                data["to_center_mouse_positions"][i_trial][i_repeat],
             ):
                 to_center_reaction_time, to_center_time = reaction_movement_times(
                     to_center_timestamps, to_center_mouse_positions
@@ -70,14 +63,18 @@ class MotorTaskStats:
             all_to_center_times.append(to_center_times)
             all_to_center_distances.append(to_center_distances)
             all_to_center_rmses.append(to_center_rmses)
-        self.to_target_reaction_times = np.array(all_to_target_reaction_times)
-        self.to_target_times = np.array(all_to_target_times)
-        self.to_target_distances = np.array(all_to_target_distances)
-        self.to_target_rmses = np.array(all_to_target_rmses)
-        self.to_center_reaction_times = np.array(all_to_center_reaction_times)
-        self.to_center_times = np.array(all_to_center_times)
-        self.to_center_distances = np.array(all_to_center_distances)
-        self.to_center_rmses = np.array(all_to_center_rmses)
+        self.to_target_reaction_times: np.ndarray = np.array(
+            all_to_target_reaction_times
+        )
+        self.to_target_times: np.ndarray = np.array(all_to_target_times)
+        self.to_target_distances: np.ndarray = np.array(all_to_target_distances)
+        self.to_target_rmses: np.ndarray = np.array(all_to_target_rmses)
+        self.to_center_reaction_times: np.ndarray = np.array(
+            all_to_center_reaction_times
+        )
+        self.to_center_times: np.ndarray = np.array(all_to_center_times)
+        self.to_center_distances: np.ndarray = np.array(all_to_center_distances)
+        self.to_center_rmses: np.ndarray = np.array(all_to_center_rmses)
 
 
 def reaction_movement_times(

--- a/src/motor_task_prototype/task.py
+++ b/src/motor_task_prototype/task.py
@@ -5,10 +5,9 @@ from typing import Union
 
 import numpy as np
 from motor_task_prototype import vis as mtpvis
-from motor_task_prototype.experiment import new_experiment_from_trialhandler
+from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.geom import PointRotator
 from psychopy.clock import Clock
-from psychopy.data import TrialHandlerExt
 from psychopy.event import Mouse
 from psychopy.event import xydist
 from psychopy.hardware.keyboard import Keyboard
@@ -20,31 +19,33 @@ from psychopy.visual.window import Window
 
 
 def run_task(
-    experiment: TrialHandlerExt, win: Optional[Window] = None, win_type: str = "pyglet"
-) -> Optional[TrialHandlerExt]:
-    close_window_when_done = False
-
+    experiment: MotorTaskExperiment,
+    win: Optional[Window] = None,
+    win_type: str = "pyglet",
+) -> bool:
     def _clean_up_and_return(
-        return_experiment: bool = False,
-    ) -> Optional[TrialHandlerExt]:
+        write_results_to_experiment: bool = False,
+    ) -> bool:
         if win is not None and close_window_when_done:
             win.close()
-        if return_experiment:
-            return exp
-        return None
+        if write_results_to_experiment:
+            experiment.trial_handler_with_results = trial_handler
+            experiment.has_unsaved_changes = True
+        return write_results_to_experiment
 
-    exp = new_experiment_from_trialhandler(experiment)
-    if exp is None:
+    close_window_when_done = False
+    if not experiment.trial_list:
         return _clean_up_and_return()
+    trial_handler = experiment.create_trialhandler()
     if win is None:
         win = Window(fullscr=True, units="height", winType=win_type)
         close_window_when_done = True
     mouse = Mouse(visible=False, win=win)
     clock = Clock()
     kb = Keyboard()
-    mtpvis.splash_screen(exp.extraInfo["metadata"], win)
-    condition_trial_indices: List[List[int]] = [[] for _ in exp.trialList]
-    for trial in exp:
+    mtpvis.splash_screen(experiment.metadata, win)
+    condition_trial_indices: List[List[int]] = [[] for _ in trial_handler.trialList]
+    for trial in trial_handler:
         targets: ElementArrayStim = mtpvis.make_targets(
             win,
             trial["num_targets"],
@@ -66,9 +67,11 @@ def run_task(
         if trial["show_cursor_path"]:
             drawables.append(cursor_path)
             drawables.append(prev_cursor_path)
-        condition_trial_indices[exp.thisIndex].append(exp.thisTrialN)
+        condition_trial_indices[trial_handler.thisIndex].append(
+            trial_handler.thisTrialN
+        )
         is_final_trial_of_block = (
-            len(condition_trial_indices[exp.thisIndex]) == trial["weight"]
+            len(condition_trial_indices[trial_handler.thisIndex]) == trial["weight"]
         )
         post_trial_delay = trial["post_trial_delay"]
         if is_final_trial_of_block:
@@ -79,13 +82,17 @@ def run_task(
         trial_to_target_mouse_positions = []
         trial_to_center_mouse_positions = []
         mouse_pos = (0.0, 0.0)
-        for index in trial["target_indices"]:
+        for index in np.fromstring(trial["target_indices"], dtype="int", sep=" "):
             indices = [index]
             if not trial["automove_cursor_to_center"]:
                 indices.append(trial["num_targets"])
             for target_index in indices:
                 mtpvis.update_target_colors(targets, None)
-                if target_index != trial["num_targets"]:
+                is_central_target = target_index == trial["num_targets"]
+                if is_central_target:
+                    prev_cursor_path.vertices = cursor_path.vertices
+                    cursor_path.vertices = [prev_cursor_path.vertices[-1]]
+                else:
                     cursor_path.vertices = [(0, 0)]
                     prev_cursor_path.vertices = [(0, 0)]
                     mouse.setPos((0.0, 0.0))
@@ -98,13 +105,10 @@ def run_task(
                             return _clean_up_and_return()
                     mouse.setPos((0.0, 0.0))
                     mouse_pos = (0.0, 0.0)
-                else:
-                    prev_cursor_path.vertices = cursor_path.vertices
-                    cursor_path.vertices = [prev_cursor_path.vertices[-1]]
                 mtpvis.update_target_colors(targets, target_index)
                 if trial["play_sound"]:
                     Sound("A", secs=0.3, blockSize=512).play()
-                if target_index != trial["num_targets"]:
+                if not is_central_target:
                     trial_target_pos.append(targets.xys[target_index])
                 dist = xydist(mouse_pos, targets.xys[target_index])
                 mouse_times = [0]
@@ -114,7 +118,7 @@ def run_task(
                 clock.reset()
                 win.recordFrameIntervals = True
                 target_size = trial["target_size"]
-                if target_index == trial["num_targets"]:
+                if is_central_target:
                     target_size = trial["central_target_size"]
                 while dist > target_size and clock.getTime() < trial["target_duration"]:
                     mouse_pos = point_rotator(mouse.getPos())
@@ -128,26 +132,32 @@ def run_task(
                     if not mtpvis.draw_and_flip(win, drawables, kb):
                         return _clean_up_and_return()
                 win.recordFrameIntervals = False
-                if target_index == trial["num_targets"]:
+                if is_central_target:
                     trial_to_center_timestamps.append(np.array(mouse_times))
                     trial_to_center_mouse_positions.append(np.array(mouse_positions))
                 else:
                     trial_to_target_timestamps.append(np.array(mouse_times))
                     trial_to_target_mouse_positions.append(np.array(mouse_positions))
-        exp.addData("target_pos", np.array(trial_target_pos))
-        exp.addData("to_target_timestamps", np.array(trial_to_target_timestamps))
-        exp.addData(
+        trial_handler.addData("target_pos", np.array(trial_target_pos))
+        trial_handler.addData(
+            "to_target_timestamps", np.array(trial_to_target_timestamps)
+        )
+        trial_handler.addData(
             "to_target_mouse_positions", np.array(trial_to_target_mouse_positions)
         )
-        exp.addData("to_center_timestamps", np.array(trial_to_center_timestamps))
-        exp.addData(
+        trial_handler.addData(
+            "to_center_timestamps", np.array(trial_to_center_timestamps)
+        )
+        trial_handler.addData(
             "to_center_mouse_positions", np.array(trial_to_center_mouse_positions)
         )
         clock.reset()
         while clock.getTime() < post_trial_delay:
             if not mtpvis.draw_and_flip(win, [], kb):
                 return _clean_up_and_return()
-        n_trials_currently_in_block = len(condition_trial_indices[exp.thisIndex])
+        n_trials_currently_in_block = len(
+            condition_trial_indices[trial_handler.thisIndex]
+        )
         display_trial_results = trial["post_trial_display_results"] or (
             is_final_trial_of_block
             and trial["post_block_display_results"]
@@ -160,14 +170,16 @@ def run_task(
         )
         if display_trial_results:
             mtpvis.display_results(
-                exp,
-                [exp.thisTrialN],
+                trial_handler,
+                experiment.display_options,
+                [trial_handler.thisTrialN],
                 win,
             )
         if display_block_results:
             mtpvis.display_results(
-                exp,
-                condition_trial_indices[exp.thisIndex],
+                trial_handler,
+                experiment.display_options,
+                condition_trial_indices[trial_handler.thisIndex],
                 win,
             )
     if win.nDroppedFrames > 0:

--- a/src/motor_task_prototype/types.py
+++ b/src/motor_task_prototype/types.py
@@ -2,8 +2,6 @@ import sys
 from typing import List
 from typing import Union
 
-import numpy as np
-
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
@@ -14,7 +12,7 @@ class MotorTaskTrial(TypedDict):
     weight: int
     num_targets: int
     target_order: Union[str, List]
-    target_indices: Union[np.ndarray, str]
+    target_indices: str
     target_duration: float
     inter_target_duration: float
     target_distance: float

--- a/tests/helpers/gui_test_utils.py
+++ b/tests/helpers/gui_test_utils.py
@@ -2,6 +2,7 @@ import queue
 import sys
 import threading
 from time import sleep
+from typing import Any
 from typing import Callable
 from typing import Tuple
 
@@ -136,3 +137,19 @@ def pixel_color_fraction(img: np.ndarray, color: Tuple[int, int, int]) -> float:
 # return fraction of pixels in current screen of the supplied color
 def screenshot_pixel_color_fraction(color: Tuple[int, int, int]) -> float:
     return pixel_color_fraction(np.asarray(pyautogui.screenshot()), color)
+
+
+# class to receive a pyqt signal
+class SignalReceived:
+    def __init__(self, signal: Any):
+        self._signal_received = False
+        signal.connect(self._receive)
+
+    def __bool__(self) -> bool:
+        return self._signal_received
+
+    def _receive(self) -> None:
+        self._signal_received = True
+
+    def clear(self) -> None:
+        self._signal_received = False

--- a/tests/test_display_widget.py
+++ b/tests/test_display_widget.py
@@ -1,29 +1,44 @@
+import gui_test_utils as gtu
 import motor_task_prototype.display as mtpdisplay
 from motor_task_prototype.display_widget import DisplayOptionsWidget
+from motor_task_prototype.experiment import MotorTaskExperiment
+from psychopy.visual.window import Window
 from PyQt5.QtCore import Qt
 from PyQt5.QtTest import QTest
 
 
-def test_display_options_widget() -> None:
-    widget = DisplayOptionsWidget(None)
-    # initially has default display options
-    assert widget.get_display_options() == mtpdisplay.default_display_options()
-    assert widget.unsaved_changes is False
-    # set all to false
+def test_display_options_widget(window: Window) -> None:
+    widget = DisplayOptionsWidget(parent=None, win=window)
+    signal_received = gtu.SignalReceived(widget.experiment_modified)
+    # initially has default experiment with default display options
+    assert widget.experiment.display_options == mtpdisplay.default_display_options()
+    assert widget.experiment.has_unsaved_changes is True
+    assert not signal_received
+    # set an experiment with all options set to false
+    experiment = MotorTaskExperiment()
     all_false = mtpdisplay.default_display_options()
     for key in all_false:
         all_false[key] = False  # type: ignore
-    widget.set_display_options(all_false)
-    assert widget.get_display_options() == all_false
-    assert widget.unsaved_changes is False
+    experiment.display_options = all_false
+    experiment.has_unsaved_changes = False
+    widget.experiment = experiment
+    assert widget.experiment is experiment
+    assert widget.experiment.display_options == all_false
+    assert widget.experiment.has_unsaved_changes is False
+    assert not signal_received
     # modify options by clicking on each check box in turn
     for key, check_box in widget._widgets.items():
-        assert widget.get_display_options()[key] is False  # type: ignore
+        signal_received.clear()
+        assert widget.experiment.display_options[key] is False  # type: ignore
         QTest.mouseClick(check_box, Qt.MouseButton.LeftButton)
-        assert widget.unsaved_changes is True
-        assert widget.get_display_options()[key] is True  # type: ignore
+        assert widget.experiment.display_options[key] is True  # type: ignore
+        assert widget.experiment.has_unsaved_changes is True
+        assert signal_received
+        signal_received.clear()
         QTest.mouseClick(check_box, Qt.MouseButton.LeftButton)
-        assert widget.get_display_options()[key] is False  # type: ignore
+        QTest.qWait(100)
+        assert widget.experiment.display_options[key] is False  # type: ignore
+        assert signal_received
     # check that all values have the correct type
-    for value in widget.get_display_options().values():
+    for value in widget.experiment.display_options.values():
         assert type(value) is bool

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,10 +1,102 @@
-import motor_task_prototype.display as mtpdisplay
-import motor_task_prototype.experiment as mtpexp
-import motor_task_prototype.meta as mtpmeta
+import pathlib
+
+import numpy as np
+from motor_task_prototype.display import default_display_options
+from motor_task_prototype.experiment import MotorTaskExperiment
+from motor_task_prototype.meta import default_metadata
+from motor_task_prototype.trial import default_trial
 
 
-def test_new_default_experiment() -> None:
-    exp = mtpexp.new_default_experiment()
-    assert len(exp.trialList) == 1
-    assert exp.extraInfo["metadata"] == mtpmeta.default_metadata()
-    assert exp.extraInfo["display_options"] == mtpdisplay.default_display_options()
+def test_experiment_no_results(tmp_path: pathlib.Path) -> None:
+    exp = MotorTaskExperiment()
+    # default initial values
+    assert exp.trial_list == [default_trial()]
+    assert exp.metadata == default_metadata()
+    assert exp.display_options == default_display_options()
+    assert exp.trial_handler_with_results is None
+    assert exp.has_unsaved_changes is True
+    # get a trial handler for this experiment
+    th = exp.create_trialhandler()
+    assert th.trialList == [default_trial()]
+    assert th.extraInfo["metadata"] == default_metadata()
+    assert th.extraInfo["display_options"] == default_display_options()
+    assert th.finished is False
+    # modify experiment
+    exp.trial_list.append(default_trial())
+    exp.metadata["author"] = "Joe Smith"
+    exp.display_options["to_target_paths"] = False
+    assert exp.trial_handler_with_results is None
+    # get a new trial handler
+    th = exp.create_trialhandler()
+    assert th.trialList == [default_trial(), default_trial()]
+    assert th.extraInfo["metadata"]["author"] == "Joe Smith"
+    assert th.extraInfo["display_options"]["to_target_paths"] is False
+    assert th.finished is False
+    # save the experiment
+    filename = str(tmp_path / "ex1.psydat")
+    exp.save_psydat(filename)
+    assert exp.has_unsaved_changes is False
+    # load the experiment
+    exp2 = MotorTaskExperiment(filename)
+    assert exp2.metadata["author"] == "Joe Smith"
+    assert exp2.display_options["to_target_paths"] is False
+    assert exp2.has_unsaved_changes is False
+    assert exp.trial_handler_with_results is None
+    # get a new trial handler
+    th2 = exp2.create_trialhandler()
+    assert th2.trialList == [default_trial(), default_trial()]
+    assert th2.extraInfo["metadata"]["author"] == "Joe Smith"
+    assert th2.extraInfo["display_options"]["to_target_paths"] is False
+    assert th2.finished is False
+
+
+def test_experiment_with_results(
+    experiment_with_results: MotorTaskExperiment, tmp_path: pathlib.Path
+) -> None:
+    # initial experiment has existing results
+    assert experiment_with_results.trial_handler_with_results is not None
+    assert experiment_with_results.trial_handler_with_results.finished
+    assert (
+        "to_target_timestamps"
+        in experiment_with_results.trial_handler_with_results.data
+    )
+    assert experiment_with_results.has_unsaved_changes is True
+    # get a new trial handler for this experiment
+    th = experiment_with_results.create_trialhandler()
+    assert th.trialList == experiment_with_results.trial_list
+    assert th.extraInfo["metadata"] == experiment_with_results.metadata
+    assert th.extraInfo["display_options"] == experiment_with_results.display_options
+    assert "to_target_timestamps" not in th.data
+    assert th.finished is False
+    # save experiment
+    filename = str(tmp_path / "ex1.psydat")
+    experiment_with_results.save_psydat(filename)
+    assert experiment_with_results.has_unsaved_changes is False
+    # load the experiment
+    exp2 = MotorTaskExperiment(filename)
+    assert exp2.metadata == experiment_with_results.metadata
+    assert exp2.display_options == experiment_with_results.display_options
+    assert exp2.trial_list == experiment_with_results.trial_list
+    assert exp2.has_unsaved_changes is False
+    assert exp2.trial_handler_with_results is not None
+    for key in [
+        "target_pos",
+        "to_target_timestamps",
+        "to_center_timestamps",
+        "to_target_mouse_positions",
+        "to_center_mouse_positions",
+    ]:
+        for trial1, trial2 in zip(
+            exp2.trial_handler_with_results.data[key],
+            experiment_with_results.trial_handler_with_results.data[key],
+        ):
+            for rep1, rep2 in zip(trial1, trial2):
+                for data1, data2 in zip(rep1, rep2):
+                    assert np.allclose(data1, data2)
+    # get a new trial handler
+    th2 = exp2.create_trialhandler()
+    assert th2.trialList == experiment_with_results.trial_list
+    assert th2.extraInfo["metadata"] == experiment_with_results.metadata
+    assert th2.extraInfo["display_options"] == experiment_with_results.display_options
+    assert "to_target_timestamps" not in th2.data
+    assert th2.finished is False

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3,38 +3,30 @@ import pathlib
 import motor_task_prototype.display as mtpdisplay
 import motor_task_prototype.meta as mtpmeta
 import motor_task_prototype.trial as mtptrial
+from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.gui import MotorTaskGui
-from psychopy.data import TrialHandlerExt
 
 
 def test_gui_no_file() -> None:
     gui = MotorTaskGui(filename=None)
     # initially uses default metadata, display options and trials - no results
-    assert gui.metadata_widget.get_metadata() == mtpmeta.default_metadata()
-    assert (
-        gui.display_options_widget.get_display_options()
-        == mtpdisplay.default_display_options()
-    )
-    assert gui.trials_widget.get_trial_list() == [mtptrial.default_trial()]
-    assert gui.results_widget.have_results() is False
+    assert gui.experiment.metadata == mtpmeta.default_metadata()
+    assert gui.experiment.display_options == mtpdisplay.default_display_options()
+    assert gui.experiment.trial_list == [mtptrial.default_trial()]
+    assert gui.experiment.trial_handler_with_results is None
 
 
 def test_gui_file_with_results(
-    tmp_path: pathlib.Path, experiment_with_results: TrialHandlerExt
+    tmp_path: pathlib.Path, experiment_with_results: MotorTaskExperiment
 ) -> None:
     filename = str(tmp_path / "experiment.psydat")
-    experiment_with_results.saveAsPickle(filename)
+    experiment_with_results.save_psydat(filename)
     gui = MotorTaskGui(filename=filename)
+    assert gui.experiment.metadata == experiment_with_results.metadata
+    assert gui.experiment.display_options == experiment_with_results.display_options
+    assert len(gui.experiment.trial_list) == len(experiment_with_results.trial_list)
+    assert gui.experiment.trial_handler_with_results is not None
     assert (
-        gui.metadata_widget.get_metadata()
-        == experiment_with_results.extraInfo["metadata"]
+        gui.results_widget._list_trials.count()
+        == gui.experiment.trial_handler_with_results.nTotal
     )
-    assert (
-        gui.display_options_widget.get_display_options()
-        == experiment_with_results.extraInfo["display_options"]
-    )
-    assert len(gui.trials_widget.get_trial_list()) == len(
-        experiment_with_results.trialList
-    )
-    assert gui.results_widget.have_results() is True
-    assert gui.results_widget._list_trials.count() == experiment_with_results.nTotal

--- a/tests/test_meta_widget.py
+++ b/tests/test_meta_widget.py
@@ -1,5 +1,6 @@
 import gui_test_utils as gtu
 import motor_task_prototype.meta as mtpmeta
+from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.meta_widget import MetadataWidget
 from psychopy.visual.window import Window
 from PyQt5 import QtWidgets
@@ -9,9 +10,30 @@ from PyQt5.QtTest import QTest
 
 def test_metadata_widget(window: Window) -> None:
     widget = MetadataWidget(parent=None, win=window)
-    # initially has empty metadata
-    assert widget.get_metadata() == mtpmeta.empty_metadata()
-    assert widget.unsaved_changes is False
+    signal_received = gtu.SignalReceived(widget.experiment_modified)
+    # default-constructed widget has a default experiment with default metadata
+    assert widget.experiment.metadata == mtpmeta.default_metadata()
+    assert widget.experiment.has_unsaved_changes is True
+    assert not signal_received
+    screenshot = gtu.call_target_and_get_screenshot(
+        QTest.mouseClick,
+        (widget._btn_preview_metadata, Qt.MouseButton.LeftButton),
+        window,
+    )
+    # most pixels are grey
+    default_grey_pixel_fraction = gtu.pixel_color_fraction(screenshot, (128, 128, 128))
+    assert 0.850 < default_grey_pixel_fraction < 0.999
+    # a couple percent of black pixels due to black text
+    assert 0.005 <= gtu.pixel_color_fraction(screenshot, (0, 0, 0)) <= 0.050
+    experiment = MotorTaskExperiment()
+    experiment.metadata = mtpmeta.empty_metadata()
+    experiment.has_unsaved_changes = False
+    # assign experiment with empty metadata
+    widget.experiment = experiment
+    assert widget.experiment is experiment
+    assert widget.experiment.metadata == mtpmeta.empty_metadata()
+    assert widget.experiment.has_unsaved_changes is False
+    assert not signal_received
     screenshot = gtu.call_target_and_get_screenshot(
         QTest.mouseClick,
         (widget._btn_preview_metadata, Qt.MouseButton.LeftButton),
@@ -19,35 +41,44 @@ def test_metadata_widget(window: Window) -> None:
     )
     # all pixels grey except for blue continue text
     empty_grey_pixel_fraction = gtu.pixel_color_fraction(screenshot, (128, 128, 128))
-    assert 0.990 < empty_grey_pixel_fraction < 0.999
+    assert empty_grey_pixel_fraction > default_grey_pixel_fraction
     # no other text so no black pixels
     assert gtu.pixel_color_fraction(screenshot, (0, 0, 0)) == 0.000
-    # set all to defaults
-    widget.set_metadata(mtpmeta.default_metadata())
-    assert widget.get_metadata() == mtpmeta.default_metadata()
-    assert widget.unsaved_changes is False
-    screenshot = gtu.call_target_and_get_screenshot(
-        QTest.mouseClick,
-        (widget._btn_preview_metadata, Qt.MouseButton.LeftButton),
-        window,
-    )
-    # less grey pixels since we now have black text
-    assert (
-        gtu.pixel_color_fraction(screenshot, (128, 128, 128))
-        < empty_grey_pixel_fraction
-    )
-    # a couple percent of black pixels due to black text
-    assert 0.005 <= gtu.pixel_color_fraction(screenshot, (0, 0, 0)) <= 0.050
-    # reset to empty, then type in each line edit
-    widget.set_metadata(mtpmeta.empty_metadata())
-    assert widget.unsaved_changes is False
+    # reset to experiment with empty metadata, then type variable name in each line edit
+    assert widget.experiment.has_unsaved_changes is False
+    assert widget.experiment.metadata == mtpmeta.empty_metadata()
+    assert not signal_received
     for key in mtpmeta.empty_metadata().keys():
         line_edit = widget._widgets[key]
         assert line_edit is not None
         assert type(line_edit) is QtWidgets.QLineEdit
-        assert widget.get_metadata()[key] == ""  # type: ignore
+        assert widget.experiment.metadata[key] == ""  # type: ignore
+        signal_received.clear()
         QTest.keyClicks(line_edit, key)
-        assert widget.get_metadata()[key] == key  # type: ignore
-        assert widget.unsaved_changes is True
-    for key, value in widget.get_metadata().items():
+        assert widget.experiment.metadata[key] == key  # type: ignore
+        assert widget.experiment.has_unsaved_changes is True
+        assert signal_received
+    for key, value in widget.experiment.metadata.items():
+        assert value == key
+    # assign another experiment to widget & update fields
+    experiment2 = MotorTaskExperiment()
+    experiment2.has_unsaved_changes = False
+    widget.experiment = experiment2
+    assert widget.experiment is experiment2
+    assert widget.experiment.has_unsaved_changes is False
+    for key, value in mtpmeta.default_metadata().items():
+        line_edit = widget._widgets[key]
+        signal_received.clear()
+        assert line_edit is not None
+        assert type(line_edit) is QtWidgets.QLineEdit
+        assert widget.experiment.metadata[key] == value  # type: ignore
+        QTest.keyClicks(line_edit, "2")
+        assert widget.experiment.metadata[key] == value + "2"  # type: ignore
+        assert widget.experiment.has_unsaved_changes is True
+        assert signal_received
+    # experiment2 has been updated
+    for key, value in experiment2.metadata.items():
+        assert value == mtpmeta.default_metadata()[key] + "2"  # type: ignore
+    # previous experiment was not modified
+    for key, value in experiment.metadata.items():
         assert value == key

--- a/tests/test_results_widget.py
+++ b/tests/test_results_widget.py
@@ -1,40 +1,41 @@
 import gui_test_utils as gtu
+from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.results_widget import ResultsWidget
-from psychopy.data import TrialHandlerExt
 from psychopy.visual.window import Window
 from PyQt5.QtCore import Qt
 from PyQt5.QtTest import QTest
 
 
-def test_results_widget_no_experiment() -> None:
-    widget = ResultsWidget(None)
+def test_results_widget_no_experiment(window: Window) -> None:
+    widget = ResultsWidget(parent=None, win=window)
     # initially empty
-    assert widget.have_results() is False
+    assert widget.experiment.trial_handler_with_results is None
     assert widget._list_trials.count() == 0
     assert widget._btn_display_trial.isEnabled() is False
     assert widget._btn_display_condition.isEnabled() is False
 
 
 def test_results_widget_experiment_no_results(
-    experiment_no_results: TrialHandlerExt,
+    experiment_no_results: MotorTaskExperiment, window: Window
 ) -> None:
-    widget = ResultsWidget(None)
+    widget = ResultsWidget(parent=None, win=window)
     # assign experiment without results
-    widget.set_results(experiment_no_results)
-    assert widget.have_results() is False
+    widget.experiment = experiment_no_results
+    assert widget.experiment.trial_handler_with_results is None
     assert widget._list_trials.count() == 0
     assert widget._btn_display_trial.isEnabled() is False
     assert widget._btn_display_condition.isEnabled() is False
 
 
 def test_results_widget_experiment_with_results(
-    experiment_with_results: TrialHandlerExt, window: Window
+    experiment_with_results: MotorTaskExperiment, window: Window
 ) -> None:
     widget = ResultsWidget(parent=None, win=window)
     # assign experiment with results
-    widget.set_results(experiment_with_results)
+    widget.experiment = experiment_with_results
     n_trials = 4
-    assert widget.have_results() is True
+    assert widget.experiment.trial_handler_with_results is not None
+    assert widget.experiment.trial_handler_with_results.nTotal == n_trials
     assert widget._list_trials.count() == n_trials
     # select first row
     for _ in range(n_trials):
@@ -68,9 +69,10 @@ def test_results_widget_experiment_with_results(
         assert widget._btn_display_condition.isEnabled() is True
         QTest.keyClick(widget._list_trials, Qt.Key_Down)
     assert widget._list_trials.currentRow() == n_trials - 1
-    # clear results
-    widget.clear_results()
-    assert widget.have_results() is False
+    # assign a new experiment without results
+    experiment_with_results.clear_results()
+    widget.experiment = experiment_with_results
+    assert widget.experiment.trial_handler_with_results is None
     assert widget._list_trials.count() == 0
     assert widget._btn_display_trial.isEnabled() is False
     assert widget._btn_display_condition.isEnabled() is False

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,5 +1,4 @@
 import motor_task_prototype.trial as mtptrial
-import numpy as np
 
 
 def test_describe_trial() -> None:
@@ -118,32 +117,27 @@ def test_validate_trial_target_order() -> None:
     # clockwise
     trial["target_order"] = "clockwise"
     vtrial = mtptrial.validate_trial(trial)
-    assert isinstance(vtrial["target_indices"], np.ndarray)
-    assert vtrial["target_indices"].shape == (8,)
-    assert np.allclose(vtrial["target_indices"], [0, 1, 2, 3, 4, 5, 6, 7])
+    assert isinstance(vtrial["target_indices"], str)
+    assert vtrial["target_indices"] == "0 1 2 3 4 5 6 7"
     # anti-clockwise
     trial["target_order"] = "anti-clockwise"
     vtrial = mtptrial.validate_trial(trial)
-    assert isinstance(vtrial["target_indices"], np.ndarray)
-    assert vtrial["target_indices"].shape == (8,)
-    assert np.allclose(vtrial["target_indices"], [7, 6, 5, 4, 3, 2, 1, 0])
+    assert isinstance(vtrial["target_indices"], str)
+    assert vtrial["target_indices"] == "7 6 5 4 3 2 1 0"
     # random
     trial["target_order"] = "random"
     vtrial = mtptrial.validate_trial(trial)
-    assert isinstance(vtrial["target_indices"], np.ndarray)
-    assert vtrial["target_indices"].shape == (8,)
-    assert np.allclose(np.sort(vtrial["target_indices"]), [0, 1, 2, 3, 4, 5, 6, 7])
+    assert isinstance(vtrial["target_indices"], str)
+    assert len(set(vtrial["target_indices"].split(" "))) == 8
     # fixed & valid
     trial["target_order"] = "fixed"
     trial["target_indices"] = "0 1 2 3 4 5 6 7"
     vtrial = mtptrial.validate_trial(trial)
-    assert isinstance(vtrial["target_indices"], np.ndarray)
-    assert vtrial["target_indices"].shape == (8,)
-    assert np.allclose(vtrial["target_indices"], [0, 1, 2, 3, 4, 5, 6, 7])
+    assert isinstance(vtrial["target_indices"], str)
+    assert vtrial["target_indices"] == "0 1 2 3 4 5 6 7"
     # fixed & invalid - clipped to nearest valid indices
     trial["target_order"] = "fixed"
     trial["target_indices"] = "-2 8 1 5 12 -5"
     vtrial = mtptrial.validate_trial(trial)
-    assert isinstance(vtrial["target_indices"], np.ndarray)
-    assert vtrial["target_indices"].shape == (6,)
-    assert np.allclose(vtrial["target_indices"], [0, 7, 1, 5, 7, 0])
+    assert isinstance(vtrial["target_indices"], str)
+    assert vtrial["target_indices"] == "0 7 1 5 7 0"

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -7,7 +7,7 @@ import motor_task_prototype.meta as mtpmeta
 import motor_task_prototype.vis as mtpvis
 import numpy as np
 import pytest
-from psychopy.data import TrialHandlerExt
+from motor_task_prototype.experiment import MotorTaskExperiment
 from psychopy.visual.window import Window
 
 
@@ -101,9 +101,9 @@ def test_splash_screen_defaults(window: Window) -> None:
 
 
 def test_display_results_nothing(
-    experiment_with_results: TrialHandlerExt, window: Window
+    experiment_with_results: MotorTaskExperiment, window: Window
 ) -> None:
-    experiment_with_results.extraInfo["display_options"] = {
+    experiment_with_results.display_options = {
         "to_target_paths": False,
         "to_center_paths": False,
         "targets": False,
@@ -121,7 +121,14 @@ def test_display_results_nothing(
     # trial data without auto-move to center
     trial_indices = [0, 1, 2]
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.display_results, (experiment_with_results, trial_indices, window), window
+        mtpvis.display_results,
+        (
+            experiment_with_results.trial_handler_with_results,
+            experiment_with_results.display_options,
+            trial_indices,
+            window,
+        ),
+        window,
     )
     # all pixels grey except for blue continue text
     assert 0.990 < gtu.pixel_color_fraction(screenshot, (128, 128, 128)) < 0.999
@@ -130,7 +137,14 @@ def test_display_results_nothing(
     # trial data with auto-move to center
     trial_indices = [3]
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.display_results, (experiment_with_results, trial_indices, window), window
+        mtpvis.display_results,
+        (
+            experiment_with_results.trial_handler_with_results,
+            experiment_with_results.display_options,
+            trial_indices,
+            window,
+        ),
+        window,
     )
     # all pixels grey except for blue continue text
     assert 0.990 < gtu.pixel_color_fraction(screenshot, (128, 128, 128)) < 0.999
@@ -139,9 +153,9 @@ def test_display_results_nothing(
 
 
 def test_display_results_everything(
-    experiment_with_results: TrialHandlerExt, window: Window
+    experiment_with_results: MotorTaskExperiment, window: Window
 ) -> None:
-    experiment_with_results.extraInfo["display_options"] = {
+    experiment_with_results.display_options = {
         "to_target_paths": True,
         "to_center_paths": True,
         "targets": True,
@@ -159,7 +173,14 @@ def test_display_results_everything(
     # trial data without auto-move to center
     trial_indices = [0, 1, 2]
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.display_results, (experiment_with_results, trial_indices, window), window
+        mtpvis.display_results,
+        (
+            experiment_with_results.trial_handler_with_results,
+            experiment_with_results.display_options,
+            trial_indices,
+            window,
+        ),
+        window,
     )
     # less grey: lots of other colors for targets, paths and stats
     grey_pixels = gtu.pixel_color_fraction(screenshot, (128, 128, 128))
@@ -170,7 +191,14 @@ def test_display_results_everything(
     # trial data with auto-move to center
     trial_indices = [3]
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.display_results, (experiment_with_results, trial_indices, window), window
+        mtpvis.display_results,
+        (
+            experiment_with_results.trial_handler_with_results,
+            experiment_with_results.display_options,
+            trial_indices,
+            window,
+        ),
+        window,
     )
     # more grey since there are fewer paths and stats to display
     assert gtu.pixel_color_fraction(screenshot, (128, 128, 128)) > grey_pixels


### PR DESCRIPTION
- contains metadata, trial_list and display_options
- optionally also contains a TrialHandlerExt with results
- keeps track of the filename and if there are unsaved changes
  - resolves #110
- saves/loads to/from a psychopy psydat file (which is just a pickled TrialHandlerExt object)
  - call pickle directly if there are no results
  - psychopy saveAsPickle function doesn't actually save anything unless there are results
  - resolves #101
- fix inadvertent class variables that should have been instance variables
  - except for any pyqt signals: these must be class variables
