### PR TITLE
add `from __future__ import annotations` to all files

### DIFF
--- a/src/motor_task_prototype/__main__.py
+++ b/src/motor_task_prototype/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Optional
 

--- a/src/motor_task_prototype/common.py
+++ b/src/motor_task_prototype/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import logging
 from typing import Any

--- a/src/motor_task_prototype/display.py
+++ b/src/motor_task_prototype/display.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 
 import motor_task_prototype.common as mtpcommon

--- a/src/motor_task_prototype/display_widget.py
+++ b/src/motor_task_prototype/display_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 from typing import Dict
 from typing import Optional

--- a/src/motor_task_prototype/experiment.py
+++ b/src/motor_task_prototype/experiment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from typing import Optional
 

--- a/src/motor_task_prototype/geom.py
+++ b/src/motor_task_prototype/geom.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/src/motor_task_prototype/gui.py
+++ b/src/motor_task_prototype/gui.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 from typing import Optional
 

--- a/src/motor_task_prototype/meta.py
+++ b/src/motor_task_prototype/meta.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 
 import motor_task_prototype.common as mtpcommon

--- a/src/motor_task_prototype/meta_widget.py
+++ b/src/motor_task_prototype/meta_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 from typing import Dict
 from typing import Optional

--- a/src/motor_task_prototype/results_widget.py
+++ b/src/motor_task_prototype/results_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import DefaultDict
 from typing import Dict

--- a/src/motor_task_prototype/stat.py
+++ b/src/motor_task_prototype/stat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from typing import Tuple
 

--- a/src/motor_task_prototype/task.py
+++ b/src/motor_task_prototype/task.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import List
 from typing import Optional

--- a/src/motor_task_prototype/trial.py
+++ b/src/motor_task_prototype/trial.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 from typing import Dict
 from typing import List

--- a/src/motor_task_prototype/trials_widget.py
+++ b/src/motor_task_prototype/trials_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from motor_task_prototype.experiment import MotorTaskExperiment

--- a/src/motor_task_prototype/types.py
+++ b/src/motor_task_prototype/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from typing import List
 from typing import Union

--- a/src/motor_task_prototype/vis.py
+++ b/src/motor_task_prototype/vis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from typing import Optional
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import os
 import sys

--- a/tests/helpers/gui_test_utils.py
+++ b/tests/helpers/gui_test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import queue
 import sys
 import threading
@@ -5,6 +7,7 @@ from time import sleep
 from typing import Any
 from typing import Callable
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import ascii_magic
@@ -166,8 +169,8 @@ class SignalReceived:
 class ModalWidgetTimer:
     def __init__(self, keys: List[str]) -> None:
         self.timer = QtCore.QTimer()
-        self.other_mwt_to_start = None
-        self.widget_to_ignore = None
+        self.other_mwt_to_start: Optional[ModalWidgetTimer] = None
+        self.widget_to_ignore: Optional[QtWidgets.QWidget] = None
         self.keys = keys
         self.timeout = 30000
         self.timer.timeout.connect(self._send_keys)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import motor_task_prototype.common as mtpcommon
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import motor_task_prototype.display as mtpdisplay
 import pytest
 

--- a/tests/test_display_widget.py
+++ b/tests/test_display_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gui_test_utils as gtu
 import motor_task_prototype.display as mtpdisplay
 from motor_task_prototype.display_widget import DisplayOptionsWidget

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import numpy as np

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import motor_task_prototype.geom as mtpgeom
 import numpy as np
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import gui_test_utils as gtu

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import motor_task_prototype.meta as mtpmeta
 
 

--- a/tests/test_meta_widget.py
+++ b/tests/test_meta_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gui_test_utils as gtu
 import motor_task_prototype.meta as mtpmeta
 from motor_task_prototype.experiment import MotorTaskExperiment

--- a/tests/test_motor_task_prototype.py
+++ b/tests/test_motor_task_prototype.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import motor_task_prototype
 
 

--- a/tests/test_results_widget.py
+++ b/tests/test_results_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gui_test_utils as gtu
 from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.results_widget import ResultsWidget

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import motor_task_prototype.stat as mptstat
 import numpy as np
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 from time import sleep
 from typing import List

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import motor_task_prototype.trial as mtptrial
 
 

--- a/tests/test_trials_widget.py
+++ b/tests/test_trials_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gui_test_utils as gtu
 import motor_task_prototype.trial as mtptrial
 from motor_task_prototype.experiment import MotorTaskExperiment

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 from typing import List
 from typing import Tuple


### PR DESCRIPTION
- this prevents Python from evaluating type annotations at module import time
  - instead they are stored as strings
- this also allows the use of forward references within type annotations
- see https://peps.python.org/pep-0563/
