### PR TITLE
add json and Excel format import/export options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
           # see Qt debug output when loading plugins
           echo "QT_DEBUG_PLUGINS=1" >> $GITHUB_ENV
       - run: pip install -e .[tests,docs] --verbose
-      - run: python -m pytest --cov=motor_task_prototype --cov-report=xml -v -s
+      - run: python -m pytest --cov=motor_task_prototype --cov-report=xml -v -s -x
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          path: "*.*"
       - name: Build documentation
         if: runner.os == 'Linux'
         run: cd docs && make && touch _build/html/.nojekyll

--- a/src/motor_task_prototype/__init__.py
+++ b/src/motor_task_prototype/__init__.py
@@ -2,4 +2,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"

--- a/src/motor_task_prototype/common.py
+++ b/src/motor_task_prototype/common.py
@@ -37,11 +37,15 @@ def import_typed_dict(
             # import all valid keys from input_dict
             correct_type = type(default_value)
             value = input_dict[key]
-            if _has_valid_type(value, correct_type):
-                output_dict[key] = correct_type(value)  # type: ignore
-            else:
+            if not _has_valid_type(value, correct_type):
                 logging.warning(
                     f"Key '{key}' invalid: expected {correct_type}, got {type(value)} '{value}'"
+                )
+            try:
+                output_dict[key] = correct_type(value)  # type: ignore
+            except ValueError:
+                logging.warning(
+                    f"Failed to coerce Key '{key}' with type {type(value)} to correct type {correct_type}"
                 )
         else:
             # warn if a key is missing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,11 @@ def experiment_no_results() -> MotorTaskExperiment:
     trial1["weight"] = 2
     trial1["num_targets"] = 3
     experiment.trial_list = [trial0, trial1]
+    experiment.metadata["name"] = "Experiment with no results"
+    experiment.metadata["author"] = "experiment_no_results @pytest.fixture"
+    experiment.metadata["date"] = "1666"
+    experiment.display_options["to_target_rmse"] = False
+    experiment.display_options["averages"] = False
     return experiment
 
 
@@ -103,6 +108,11 @@ def experiment_with_results() -> MotorTaskExperiment:
     trial1["num_targets"] = 4
     trial1["automove_cursor_to_center"] = True
     experiment.trial_list = [trial0, trial1]
+    experiment.metadata["name"] = "Experiment with results"
+    experiment.metadata["author"] = "experiment_with_results @pytest.fixture"
+    experiment.metadata["date"] = "2000"
+    experiment.display_options["to_target_rmse"] = False
+    experiment.display_options["averages"] = False
     trial_handler = experiment.create_trialhandler()
     for trial in trial_handler:
         to_target_timestamps = []

--- a/tests/helpers/qt_test_utils.py
+++ b/tests/helpers/qt_test_utils.py
@@ -58,7 +58,9 @@ class SignalReceived:
 # https://github.com/spatial-model-editor/spatial-model-editor/blob/main/test/test_utils/qt_test_utils.hpp
 class ModalWidgetTimer:
     def __init__(
-        self, keys: List[str], start_after: Optional[ModalWidgetTimer] = None
+        self,
+        keys: List[str],
+        start_after: Optional[ModalWidgetTimer] = None,
     ) -> None:
         self._keys = keys
         if start_after is not None:
@@ -79,10 +81,17 @@ class ModalWidgetTimer:
                     QtWidgets.QFileDialog.AcceptMode, f"Accept{mode}"
                 ):
                     self._widget_type += f".{mode}"
+            print(
+                f"ModalWidgetTimer ::   - {widget.selectedNameFilter()} / {widget.nameFilters()}",
+                flush=True,
+            )
+            print(f"ModalWidgetTimer ::   - {widget.selectedFiles()}", flush=True)
         if isinstance(widget, QtWidgets.QMessageBox):
             self._widget_text = widget.text()
+            print(f"ModalWidgetTimer ::   - {widget.text()}", flush=True)
         else:
             self._widget_text = widget.windowTitle()
+            print(f"ModalWidgetTimer ::   - {widget.windowTitle()}", flush=True)
 
     def _send_keys(self) -> None:
         widget = QtWidgets.QApplication.activeModalWidget()
@@ -104,7 +113,7 @@ class ModalWidgetTimer:
             str_key = key_seq.toString()
             qt_key = Qt.Key(key_seq[0])
             print(
-                f"ModalWidgetTimer ::   - sending '{str_key} [{qt_key}]' tp {widget}",
+                f"ModalWidgetTimer ::   - sending '{str_key} [{qt_key}]' to {widget}",
                 flush=True,
             )
             QTest.keyClick(widget, qt_key)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -38,13 +38,13 @@ def test_import_display_options(caplog: pytest.LogCaptureFixture) -> None:
     ]
     for key in missing_keys:
         display_options_dict.pop(key)
-    invalid_values = ["to_center_paths"]
     display_options = mtpdisplay.import_display_options(display_options_dict)
-    for key in display_options:
-        if key in missing_keys or key in invalid_values:
-            assert display_options[key] == default_display_options[key]  # type: ignore
+    for key, value in display_options.items():
+        if key in missing_keys:
+            assert value == default_display_options[key]  # type: ignore
         else:
-            assert display_options[key] == display_options_dict[key]  # type: ignore
+            value_type = type(value)
+            assert value == value_type(display_options_dict[key])  # type: ignore
     log_messages = {r.message for r in caplog.records}
     expected_log_messages = {
         "Key 'to_center_reaction_time' missing, using default 'False'",

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -108,6 +108,38 @@ def test_experiment_with_results(
     assert th2.finished is False
 
 
+def test_experiment_to_excel(
+    experiment_with_results: MotorTaskExperiment, tmp_path: pathlib.Path
+) -> None:
+    # export to an Excel file
+    excel_file = tmp_path / "export.xlsx"
+    experiment_with_results.save_excel(str(excel_file))
+    # import this Excel file again
+    exp = MotorTaskExperiment(str(excel_file))
+    assert exp.metadata == experiment_with_results.metadata
+    assert exp.display_options == experiment_with_results.display_options
+    assert exp.trial_list == experiment_with_results.trial_list
+    assert exp.trial_handler_with_results is None
+    assert exp.has_unsaved_changes is True
+    assert exp.filename == str(excel_file.with_suffix(".psydat"))
+
+
+def test_experiment_to_json(
+    experiment_with_results: MotorTaskExperiment, tmp_path: pathlib.Path
+) -> None:
+    # export to a json file
+    json_file = tmp_path / "export.json"
+    experiment_with_results.save_json(str(json_file))
+    # import this json file again
+    exp = MotorTaskExperiment(str(json_file))
+    assert exp.metadata == experiment_with_results.metadata
+    assert exp.display_options == experiment_with_results.display_options
+    assert exp.trial_list == experiment_with_results.trial_list
+    assert exp.trial_handler_with_results is None
+    assert exp.has_unsaved_changes is True
+    assert exp.filename == str(json_file.with_suffix(".psydat"))
+
+
 def test_experiment_invalid_file(tmp_path: pathlib.Path) -> None:
     # file doesn't exist
     with pytest.raises(ValueError):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -28,9 +28,14 @@ def test_import_metadata() -> None:
     # all keys missing -> replaced with defaults
     metadata = mtpmeta.import_metadata({})
     assert metadata == mtpmeta.default_metadata()
-    # valid keys present but values have wrong type -> replaced with defaults
-    metadata = mtpmeta.import_metadata({"name": 12, "data": 2.4, "author": [1, 2, 3]})
-    assert metadata == mtpmeta.default_metadata()
-    # invalid keys are ignored
-    metadata = mtpmeta.import_metadata({"whoops": "ok"})
+    # valid keys present but values have wrong type:
+    #   - coerced to correct type if legal to do so
+    #   - otherwise replaced with defaults
+    metadata = mtpmeta.import_metadata(
+        {"name": 12, "data": 2.4, "author": [1, 2, 3], "whoops": "ok"}
+    )
+    assert metadata["name"] == "12"
+    assert metadata["author"] == "[1, 2, 3]"
+    # unknwon keys are ignored
+    assert "data" not in metadata
     assert "whoops" not in metadata


### PR DESCRIPTION
- Experiment can save/load json or Excel files
- note: these do not include any results
- add file -> export menu item to GUI to export json/excel files
- add *.json, *.xlsx, *.* filters to file -> open
- resolves #28
