### PR TITLE
add delay screen countdown and enter to skip options

### DIFF
--- a/src/motor_task_prototype/__init__.py
+++ b/src/motor_task_prototype/__init__.py
@@ -5,4 +5,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/src/motor_task_prototype/meta.py
+++ b/src/motor_task_prototype/meta.py
@@ -6,20 +6,6 @@ import motor_task_prototype.common as mtpcommon
 from motor_task_prototype.types import MotorTaskMetadata
 
 
-def empty_metadata() -> MotorTaskMetadata:
-    return {
-        "name": "",
-        "subject": "",
-        "date": "",
-        "author": "",
-        "display_title": "",
-        "display_text1": "",
-        "display_text2": "",
-        "display_text3": "",
-        "display_text4": "",
-    }
-
-
 def default_metadata() -> MotorTaskMetadata:
     return {
         "name": "Experiment",
@@ -27,13 +13,15 @@ def default_metadata() -> MotorTaskMetadata:
         "date": "2022/01/01",
         "author": "Author",
         "display_title": "Welcome to the experiment",
-        "display_text1": "When a target is presented, "
-        "you will hear an audible tone and the target circle will turn red.",
-        "display_text2": "Try to move the cursor to the red circle "
+        "display_text1": "When a target is presented the target circle will turn red.",
+        "display_text2": "You will also hear an audible tone",
+        "display_text3": "Try to move the cursor to the red circle "
         "as quickly and accurately as you can.",
-        "display_text3": "You can abort the experiment at any time "
+        "display_text4": "You can abort the experiment at any time "
         "by pressing the Escape key.",
-        "display_text4": "Otherwise, press Enter " "when you are ready to begin.",
+        "display_duration": 60,
+        "show_delay_countdown": True,
+        "enter_to_skip_delay": True,
     }
 
 
@@ -48,6 +36,9 @@ def metadata_labels() -> Dict:
         "display_text2": "Main text line 2",
         "display_text3": "Main text line 3",
         "display_text4": "Main text line 4",
+        "display_duration": "Display duration (seconds)",
+        "show_delay_countdown": "Display a countdown",
+        "enter_to_skip_delay": "Skip by pressing enter key",
     }
 
 

--- a/src/motor_task_prototype/results_widget.py
+++ b/src/motor_task_prototype/results_widget.py
@@ -56,31 +56,27 @@ class ResultsWidget(QtWidgets.QWidget):
         self._btn_display_trial.setEnabled(valid)
         self._btn_display_condition.setEnabled(valid)
 
-    def _btn_display_trial_clicked(self) -> None:
+    def _display_results(self, all_trials_for_this_condition: bool) -> None:
         row = self._list_trials.currentRow()
         if not self._is_valid(row):
             return
         display_results(
+            60,
+            True,
+            False,
             self._experiment.trial_handler_with_results,
             self._experiment.display_options,
             row,
-            False,
+            all_trials_for_this_condition,
             win=self._win,
             win_type=self._win_type,
         )
 
+    def _btn_display_trial_clicked(self) -> None:
+        self._display_results(False)
+
     def _btn_display_condition_clicked(self) -> None:
-        row = self._list_trials.currentRow()
-        if not self._is_valid(row):
-            return
-        display_results(
-            self._experiment.trial_handler_with_results,
-            self._experiment.display_options,
-            row,
-            True,
-            win=self._win,
-            win_type=self._win_type,
-        )
+        self._display_results(True)
 
     @property
     def experiment(self) -> MotorTaskExperiment:

--- a/src/motor_task_prototype/trial.py
+++ b/src/motor_task_prototype/trial.py
@@ -41,8 +41,10 @@ def default_trial() -> MotorTaskTrial:
         "cursor_rotation_degrees": 0.0,
         "post_trial_delay": 0.0,
         "post_trial_display_results": False,
-        "post_block_delay": 0.0,
+        "post_block_delay": 5.0,
         "post_block_display_results": True,
+        "show_delay_countdown": True,
+        "enter_to_skip_delay": True,
     }
 
 
@@ -68,6 +70,8 @@ def trial_labels() -> Dict:
         "post_trial_display_results": "Display results after each trial",
         "post_block_delay": "Delay after last trial (secs)",
         "post_block_display_results": "Display results after this block",
+        "show_delay_countdown": "Display a countdown during delays",
+        "enter_to_skip_delay": "Skip delay by pressing enter key",
     }
 
 

--- a/src/motor_task_prototype/types.py
+++ b/src/motor_task_prototype/types.py
@@ -31,6 +31,8 @@ class MotorTaskTrial(TypedDict):
     post_trial_display_results: bool
     post_block_delay: float
     post_block_display_results: bool
+    show_delay_countdown: bool
+    enter_to_skip_delay: bool
 
 
 class MotorTaskDisplayOptions(TypedDict):
@@ -61,3 +63,6 @@ class MotorTaskMetadata(TypedDict):
     display_text2: str
     display_text3: str
     display_text4: str
+    display_duration: float
+    show_delay_countdown: bool
+    enter_to_skip_delay: bool

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -22,6 +22,9 @@ def test_import_metadata() -> None:
         "display_text2": "t2",
         "display_text3": "t3",
         "display_text4": "t4",
+        "display_duration": 123,
+        "show_delay_countdown": False,
+        "enter_to_skip_delay": False,
     }
     metadata = mtpmeta.import_metadata(valid_dict)
     assert metadata == valid_dict

--- a/tests/test_trial.py
+++ b/tests/test_trial.py
@@ -31,7 +31,7 @@ def test_describe_trials() -> None:
 
 def test_default_trial() -> None:
     trial = mtptrial.default_trial()
-    assert len(trial) == 20
+    assert len(trial) == 22
     assert isinstance(trial["target_indices"], str)
     assert len(trial["target_indices"].split(" ")) == trial["num_targets"]
 
@@ -66,6 +66,8 @@ def test_import_trial() -> None:
         "post_trial_display_results": True,
         "post_block_delay": 2.0,
         "post_block_display_results": False,
+        "show_delay_countdown": False,
+        "enter_to_skip_delay": True,
     }
     # all valid keys are imported
     trial = mtptrial.import_trial(trial_dict)

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -104,7 +104,7 @@ def test_update_target_colors(window: Window, n_targets: int) -> None:
 def test_splash_screen_defaults(window: Window) -> None:
     metadata = mtpmeta.default_metadata()
     screenshot = gtu.call_target_and_get_screenshot(
-        mtpvis.splash_screen, (metadata, window), window
+        mtpvis.splash_screen, (1000, True, False, metadata, window), window
     )
     # most pixels grey except for black main text and blue continue text
     assert 0.900 < gtu.pixel_color_fraction(screenshot, (128, 128, 128)) < 0.999
@@ -139,6 +139,9 @@ def test_display_results_nothing(
         screenshot = gtu.call_target_and_get_screenshot(
             mtpvis.display_results,
             (
+                60,
+                True,
+                False,
                 experiment_with_results.trial_handler_with_results,
                 experiment_with_results.display_options,
                 0,
@@ -155,6 +158,9 @@ def test_display_results_nothing(
         screenshot = gtu.call_target_and_get_screenshot(
             mtpvis.display_results,
             (
+                60,
+                True,
+                False,
                 experiment_with_results.trial_handler_with_results,
                 experiment_with_results.display_options,
                 3,
@@ -194,6 +200,9 @@ def test_display_results_everything(
         screenshot = gtu.call_target_and_get_screenshot(
             mtpvis.display_results,
             (
+                60,
+                True,
+                False,
                 experiment_with_results.trial_handler_with_results,
                 experiment_with_results.display_options,
                 0,
@@ -212,6 +221,9 @@ def test_display_results_everything(
         screenshot = gtu.call_target_and_get_screenshot(
             mtpvis.display_results,
             (
+                60,
+                True,
+                False,
                 experiment_with_results.trial_handler_with_results,
                 experiment_with_results.display_options,
                 3,


### PR DESCRIPTION
- add new options to trial
  - `show_delay_countdown`: bool
  - `enter_to_skip_delay`: bool
- add the same plus the duration to metadata
  - `display_duration`: float
  - `show_delay_countdown`: bool
  - `enter_to_skip_delay`: bool
- extend metadata widget to deal with float / bool types
- refactor vis functionality
- resolves #135
- resolves #124
- resolves #123
