### PR TITLE
add statistics and raw results to Excel export

### DIFF
--- a/src/motor_task_prototype/__init__.py
+++ b/src/motor_task_prototype/__init__.py
@@ -5,4 +5,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/src/motor_task_prototype/experiment.py
+++ b/src/motor_task_prototype/experiment.py
@@ -13,6 +13,7 @@ from motor_task_prototype.display import default_display_options
 from motor_task_prototype.display import import_display_options
 from motor_task_prototype.meta import default_metadata
 from motor_task_prototype.meta import import_metadata
+from motor_task_prototype.stat import append_stats_data_to_excel
 from motor_task_prototype.stat import stats_dataframe
 from motor_task_prototype.trial import default_trial
 from motor_task_prototype.trial import import_trial
@@ -107,6 +108,8 @@ class MotorTaskExperiment:
             pd.DataFrame(self.trial_list).to_excel(
                 writer, sheet_name="trial_list", index=False
             )
+            if self.stats is not None:
+                append_stats_data_to_excel(self.stats, writer)
 
     def load_excel(self, filename: str) -> None:
         dfs = pd.read_excel(filename, ["metadata", "display_options", "trial_list"])

--- a/src/motor_task_prototype/task.py
+++ b/src/motor_task_prototype/task.py
@@ -10,6 +10,7 @@ from motor_task_prototype import vis as mtpvis
 from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.geom import PointRotator
 from motor_task_prototype.geom import to_target_dists
+from motor_task_prototype.stat import stats_dataframe
 from psychopy.clock import Clock
 from psychopy.event import Mouse
 from psychopy.hardware.keyboard import Keyboard
@@ -32,6 +33,7 @@ def run_task(
             win.close()
         if write_results_to_experiment:
             experiment.trial_handler_with_results = trial_handler
+            experiment.stats = stats_dataframe(trial_handler)
             experiment.has_unsaved_changes = True
         return write_results_to_experiment
 
@@ -211,6 +213,8 @@ def run_task(
         trial_handler.addData(
             "to_center_mouse_positions", np.array(trial_to_center_mouse_positions)
         )
+        if trial["automove_cursor_to_center"]:
+            trial_to_center_success = [True] * trial["num_targets"]
         trial_handler.addData("to_center_success", np.array(trial_to_center_success))
         if trial["post_trial_delay"] > 0:
             mtpvis.display_results(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pyautogui
 import pytest
 from motor_task_prototype.experiment import MotorTaskExperiment
 from motor_task_prototype.geom import points_on_circle
+from motor_task_prototype.stat import stats_dataframe
 from motor_task_prototype.trial import default_trial
 from psychopy.gui.qtgui import ensureQtApp
 from psychopy.visual.window import Window
@@ -147,7 +148,10 @@ def experiment_with_results() -> MotorTaskExperiment:
         trial_handler.addData(
             "to_center_mouse_positions", np.array(to_center_mouse_positions)
         )
+        if trial["automove_cursor_to_center"]:
+            to_center_success = [True] * trial["num_targets"]
         trial_handler.addData("to_center_success", np.array(to_center_success))
     experiment.trial_handler_with_results = trial_handler
+    experiment.stats = stats_dataframe(trial_handler)
     experiment.has_unsaved_changes = True
     return experiment


### PR DESCRIPTION
- add "statistics" sheet with all calculated statistics
  - split (x,y) values into separate x, y columns
- add a sheet for each trial
  - timestamps and mouse positions as vertical arrays of data
  - split (x,y) values into separate x, y columns
- ignore these sheets when importing from Excel
- resolves #149

also

minor improvements to results data

- to_center_success is now True for automove_to_center experiments
  - previously it was an empty array which prevented this column being imported as bool by pandas
- stack positions to explicitly make them 2d arrays instead of arrays of arrays
