### PR TITLE
Collect cursor movement before target is visible

### DIFF
--- a/src/motor_task_prototype/__init__.py
+++ b/src/motor_task_prototype/__init__.py
@@ -5,4 +5,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/src/motor_task_prototype/stat.py
+++ b/src/motor_task_prototype/stat.py
@@ -174,14 +174,14 @@ def _reaction_time(
     mouse_positions: np.ndarray,
     epsilon: float = 1e-12,
 ) -> float:
-    if mouse_times.shape[0] != mouse_positions.shape[0] or mouse_times.shape[0] <= 1:
+    if mouse_times.shape[0] != mouse_positions.shape[0] or mouse_times.shape[0] == 0:
         return np.nan
-    i = 1
+    i = 0
     while xydist(mouse_positions[0], mouse_positions[i]) < epsilon and i + 1 < len(
         mouse_times
     ):
         i += 1
-    return mouse_times[i] - mouse_times[1]
+    return mouse_times[i]
 
 
 def _distance(mouse_positions: np.ndarray) -> float:

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -68,14 +68,15 @@ def test_distance() -> None:
 def test_reaction_movement_time() -> None:
     for times in [
         [0.0, 0.1],
-        [1.0, 2.0],
+        [-1.0, -0.5],
         [0.0, 2.0, 4.0, 6.0],
+        [-0.9, -0.7, -0.5, -0.3, -0.1, 0.1, 0.3, 0.5],
         [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.7, 1.0, 1.1, 1.2],
     ]:
         n = len(times)
         for n_zeros in range(1, n):
             positions = [[-1e-13, 1e-14]] * n_zeros + [[1, 1]] * (n - n_zeros)
-            reaction_time = max(0.0, times[n_zeros] - times[1])
+            reaction_time = times[n_zeros]
             assert np.allclose(
                 mtpstat._reaction_time(np.array(times), np.array(positions)),
                 [reaction_time],


### PR DESCRIPTION
- include these movements in the displayed cursor paths
- include in the data with negative timestamps (where time = 0 is target display time)
- `reaction_time` can now be negative (if movement starts before target is displayed)
- `time` is still the time from target display to target reached
- `movement_time` is `time` minus `reaction_time`
- RMSE and distance measures include these movements
- resolves #150

also, while mouse cursor should be frozen:

- call `mouse.setPos()` with initial mouse position before each window flip
- minimises "jumping" of cursor when it is unfrozen
- resolves #156
