### PR TITLE
add support for psychopy 2023.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "windows-latest"]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: check-readthedocs
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.1
     hooks:
       - id: mypy
         additional_dependencies: [numpy, PyQt5-stubs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
 ]
-dependencies = ["psychopy", "numpy", "click", "PyQt5"]
+dependencies = ["psychopy", "psychopy-sounddevice", "numpy", "click", "PyQt5"]
 dynamic = ["version"]
 
 [project.scripts]
@@ -36,14 +36,21 @@ Issues = "https://github.com/ssciwr/motor-task-prototype/issues"
 Documentation = "https://ssciwr.github.io/motor-task-prototype/"
 
 [project.optional-dependencies]
-tests = ["pytest", "pytest-cov", "pyautogui", "ascii-magic", "keyboard"]
+tests = [
+  "pytest",
+  "pytest-cov",
+  "pytest-randomly",
+  "pyautogui",
+  "ascii-magic",
+  "keyboard",
+]
 docs = [
   "ipykernel",
   "matplotlib",
   "nbsphinx",
   "pandoc",
   "sphinx>=4.5.0",
-  "sphinx_rtd_theme>=1.0.0"
+  "sphinx_rtd_theme>=1.0.0",
 ]
 
 [tool.setuptools.dynamic]

--- a/src/motor_task_prototype/joystick_wrapper.py
+++ b/src/motor_task_prototype/joystick_wrapper.py
@@ -39,6 +39,8 @@ def _updated_joystick() -> joystick.Joystick:
 
 def get_joystick() -> Optional[joystick.Joystick]:
     global js
+    if joystick.getNumJoysticks() == 0:
+        return None
     try:
         js = _updated_joystick()
     except Exception as e:

--- a/src/motor_task_prototype/task.py
+++ b/src/motor_task_prototype/task.py
@@ -67,7 +67,7 @@ def run_task(experiment: MotorTaskExperiment, win: Optional[Window] = None) -> b
             )
             if trial["target_order"] == "random":
                 rng.shuffle(target_indices)
-            targets: ElementArrayStim = mtpvis.make_targets(
+            targets = mtpvis.make_targets(
                 win,
                 trial["num_targets"],
                 trial["target_distance"],
@@ -182,7 +182,7 @@ def run_task(experiment: MotorTaskExperiment, win: Optional[Window] = None) -> b
                             target_labels, trial["show_inactive_targets"], target_index
                         )
                     if trial["play_sound"]:
-                        Sound("A", secs=0.3, blockSize=1024).play()
+                        Sound("A", secs=0.3, blockSize=1024, stereo=True).play()
                     if not is_central_target:
                         trial_target_pos.append(targets.xys[target_index])
                     dist_correct, dist_any = to_target_dists(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 # session scope means it is only called once
 # so this fixture runs once before any tests
 def tests_init() -> None:
-    # use GLFW backend for tests as it works better with Xvfb:
-    mtpconfig.win_type = "glfw"
     # opencv-python installs its own qt version and sets env vars accordingly
     # we remove these to avoid pyqt picking up their XCB QPA plugin & crashing
     for k, v in os.environ.items():
@@ -79,9 +77,11 @@ def experiment_no_results() -> MotorTaskExperiment:
     trial0["target_duration"] = 30.0
     trial0["inter_target_duration"] = 0.0
     trial0["post_block_display_results"] = False
+    trial0["post_block_delay"] = 0.1
     trial1 = copy.deepcopy(trial0)
     trial1["weight"] = 2
     trial1["num_targets"] = 3
+    trial1["post_block_delay"] = 0.1
     experiment.trial_list = [trial0, trial1]
     experiment.metadata["name"] = "Experiment with no results"
     experiment.metadata["author"] = "experiment_no_results @pytest.fixture"

--- a/tests/helpers/gui_test_utils.py
+++ b/tests/helpers/gui_test_utils.py
@@ -7,7 +7,7 @@ from time import sleep
 from typing import Callable
 from typing import Tuple
 
-import ascii_magic
+from ascii_magic import AsciiArt
 from psychopy.visual.window import Window
 
 if sys.platform.startswith("win"):
@@ -19,7 +19,7 @@ import pyautogui
 
 # print screenshot as ascii art to terminal for debugging
 def ascii_screenshot() -> None:
-    print(f"\n{ascii_magic.from_image(pyautogui.screenshot())}\n", flush=True)
+    AsciiArt(pyautogui.screenshot()).to_terminal()
 
 
 # simulate user pressing Enter key
@@ -63,7 +63,7 @@ def get_screenshot_when_ready(
     screenshot_before: np.ndarray,
     screenshot_queue: queue.Queue,
     min_rms_diff: float = 0.1,
-    delay_between_screenshots: float = 0.5,
+    delay_between_screenshots: float = 0.2,
 ) -> None:
     s0 = np.asarray(screenshot_before)
     sleep(delay_between_screenshots)
@@ -85,7 +85,7 @@ def get_screenshot_when_ready(
             print("Stuck waiting for screen to be ready", flush=True)
             print(f"Mean pixel: {np.mean(s1)}", flush=True)
             ascii_screenshot()
-    print(f"\n{ascii_magic.from_image(img)}\n", flush=True)
+    AsciiArt(img).to_terminal()
     screenshot_queue.put(s1)
     # press enter to close screen
     press_enter()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -16,12 +16,12 @@ from psychopy.visual.window import Window
 def move_mouse_to_target(
     target_pixel: Tuple[float, float],
     target_color: Tuple[int, int, int] = (255, 0, 0),
-    movement_time: float = 0.2,
+    movement_time: float = 0.1,
 ) -> None:
     # wait until target is activated
     attempts = 0
     while not gtu.pixel_color(target_pixel, target_color):
-        sleep(0.2)
+        sleep(0.1)
         # press Enter in case we are looking at a splash / display_results screen
         gtu.press_enter()
         attempts += 1


### PR DESCRIPTION
- add `psychopy-sounddevice` to dependencies
- specify `stereo=True` in Sound()
  - workaround for https://github.com/psychopy/psychopy-sounddevice/issues/2
- use pyglet backend instead of glfw in tests
- check `getNumJoysticks()` is non-zero before calling `Joystick(0)`
  - psychopy previously raised an exception, but now just logs a warning
- resolves #168

also

- reduce post-block wait time in trials used in tests
- reduce mouse move time & pre-screenshot wait time in tests
- add pytest-randomly to test deps to randomise test execution order
- update ascii-magic use to use new v2 API
- add python 3.10 to CI jobs
