### PR TITLE
Add excel data export option: one page per trial instead of per target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,4 +57,4 @@ repos:
       - id: flake8
         args:
           - "--max-line-length=88"
-          - "--ignore=E501,W503"
+          - "--ignore=E501,W503,E203"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ motor-task-prototype
    quickstart/create-experiment
    quickstart/run-experiment
    quickstart/display-results
+   quickstart/share-experiment
 
 .. toctree::
    :maxdepth: 2

--- a/docs/quickstart/create-experiment.rst
+++ b/docs/quickstart/create-experiment.rst
@@ -1,7 +1,9 @@
 Creating a new experiment
 =========================
 
-To create a new experiment, go to File -> New, or press ``Ctrl+N``, or click on the white new document toolbar button
+To create a new experiment, go to File -> New,
+or press ``Ctrl+N``,
+or click on the white new document toolbar button.
 
 .. figure:: images/gui.png
    :alt: Graphical User Interface
@@ -14,12 +16,12 @@ Metadata
 
 In the Metadata section you can edit the metadata for the experiment,
 as well as the text that should be displayed before the experiment begins.
-To see a preview of what the splash screen will look like, click on "Preview Splash Screen"
+To see a preview of what the splash screen will look like, click on "Preview Splash Screen".
 
 .. figure:: images/meta.png
    :alt: Metadata
 
-   Metadata: Information about the experiment and text to display before it starts
+   Metadata: Information about the experiment and text to display before it starts.
 
 
 Display Options
@@ -30,7 +32,7 @@ You can choose which results and statistics to display in the Display Options se
 .. figure:: images/display-options.png
    :alt: Display Options
 
-   Display Options: select which results and statistics to display
+   Display Options: select which results and statistics to display.
 
 
 Trial Conditions
@@ -42,7 +44,7 @@ Conditions can be added, re-ordered, edited and removed using the buttons below 
 .. figure:: images/trial-conditions.png
    :alt: Trial Conditions
 
-   The list of conditions used in the trial
+   The list of conditions used in the trial.
 
 To edit a trial, either click "Edit" or double click on the trial.
 This will then open a dialog box where the trial parameters can be adjusted.
@@ -51,7 +53,7 @@ When you are finished, click "OK".
 .. figure:: images/trial-screen.png
    :alt: trial settings dialog
 
-   Dialog to edit the settings for a trial
+   Dialog to edit the settings for a trial.
 
 Note on "Target indices"
    * if "Target order" is "fixed" then this lists the targets in the order to be displayed

--- a/docs/quickstart/display-results.rst
+++ b/docs/quickstart/display-results.rst
@@ -7,7 +7,7 @@ You can also display all the trials with the same conditions with "Display Condi
 .. figure:: images/results-list.png
    :alt: Results
 
-   Results: a list of trials which can be displayed
+   Results: a list of trials which can be displayed.
 
 
 Display options
@@ -18,7 +18,7 @@ You can choose which results and statistics to display in the Display Options se
 .. figure:: images/display-options.png
    :alt: Display Options
 
-   Display Options: select which results and statistics to display
+   Display Options: select which results and statistics to display.
 
 
 Results

--- a/docs/quickstart/install.rst
+++ b/docs/quickstart/install.rst
@@ -33,7 +33,11 @@ If you already have a Python environment and git you can install using pip:
 ``pip install git+https://github.com/ssciwr/motor-task-prototype``
 
 .. note::
-   Note this also installs psychopy with pip, which may need additional
+   On linux you will also need to give your Python executable permission
+   to set its own priority: ``sudo setcap cap_sys_nice=eip /path/to/python/binary``.
+
+.. note::
+   This method also installs the psychopy library with pip, which may need additional
    system libraries and configuration steps to work properly,
    which is probably why they provide standalone installers for
    Psychopy on Windows and Mac which bundle all the requirements.

--- a/docs/quickstart/run-experiment.rst
+++ b/docs/quickstart/run-experiment.rst
@@ -1,7 +1,9 @@
 Running an experiment
 =====================
 
-To run an experiment, got to Experiment -> Run, or press ``Ctrl+R``, or click on the circular green toolbar button
+To run an experiment, got to Experiment -> Run,
+or press ``Ctrl+R``,
+or click on the circular green toolbar button.
 
 Splash screen
 -------------

--- a/docs/quickstart/share-experiment.rst
+++ b/docs/quickstart/share-experiment.rst
@@ -1,0 +1,96 @@
+Sharing experiments
+===================
+
+Experiments can be exported in different formats: psydat, Excel, and json.
+Psydat is the default format used by Motor Task Prototype,
+which can also be opened from Python scripts or Jupyter notebooks.
+The Excel and json formats are provided to allow experiments
+and results to be shared, analysed and modified
+without requiring the Motor Task Prototype software to do so.
+
+.. list-table:: File format comparison
+   :widths: 25 25 25 25
+   :header-rows: 1
+
+   * -
+     - psydat
+     - Excel
+     - json
+   * - Export experiment
+     - Yes
+     - Yes
+     - Yes
+   * - Import experiment
+     - Yes
+     - Yes
+     - Yes
+   * - Export results
+     - Yes
+     - Yes
+     - No
+   * - Import results
+     - Yes
+     - No
+     - No
+
+psydat
+------
+
+This is the default file format, which includes the experiment results.
+These files can be opened in the Motor Task Prototype GUI or in Python
+(see the example notebook for more information).
+
+Excel
+-----
+
+Experiments can also be exported as Excel spreadsheets.
+The first 3 pages in the spreadsheet define the experiment:
+
+* metadata
+* display_options
+* trial_list
+
+These values can be edited in Excel and then the modified experiment can
+be opened in the Motor Task Prototype GUI (File -> Open, choose Excel as filetype).
+Note that results are not imported from an Excel file.
+
+The excel sheet also contains a statistics page with calculated statistics for each trial.
+Then there is a sheet of data for each trial in the experiment with the following columns:
+
+* timestamps
+   * start at 0 for each trial, increase throughout the trial
+* mouse_positions_x
+   * x coordinate of mouse at this timestamp
+* mouse_positions_y
+   * y coordinate of mouse at this timestamp
+* i_target
+   * ``-99`` if no target is visible
+   * ``-1`` if central target is visible
+   * otherwise index (e.g. ``0``, ``1``, etc) of current displayed target
+* target_x
+   * x coordinate of currently visible target
+   * ``-99`` if no target is visible
+* target_y
+   * y coordinate of currently visible target
+   * ``-99`` if no target is visible
+
+There is also the option to export a separate page of data for each target,
+so a single trial with 8 targets would result in 8 separate pages of experiment data.
+In this case for each target the timestamps begin at a negative value,
+and reach zero when the target is displayed.
+
+json
+----
+
+Experiments can also be exported as a json text file.
+This is a convenient format for sharing experimental setups,
+as it can be easily read and modified in a text editor.
+These files can also be opened in the Motor Task Prototype GUI
+(File -> Open, choose JSON as filetype).
+The json file contains all the information required to define the experiment:
+
+* metadata
+* display_options
+* trial_list
+
+This format does not include any statistics or experimental results.

--- a/src/motor_task_prototype/experiment.py
+++ b/src/motor_task_prototype/experiment.py
@@ -95,7 +95,12 @@ class MotorTaskExperiment:
         self.filename = filename
         self.has_unsaved_changes = False
 
-    def save_excel(self, filename: str) -> None:
+    def save_excel(self, filename: str, data_format: str) -> None:
+        """
+        data_format can be
+        - "trial": one sheet of data exported per trial
+        - "target: one sheet of data exported per target
+        """
         if not filename.endswith(".xlsx"):
             filename += ".xlsx"
         with pd.ExcelWriter(filename) as writer:
@@ -109,7 +114,7 @@ class MotorTaskExperiment:
                 writer, sheet_name="trial_list", index=False
             )
             if self.stats is not None:
-                append_stats_data_to_excel(self.stats, writer)
+                append_stats_data_to_excel(self.stats, writer, data_format)
 
     def load_excel(self, filename: str) -> None:
         dfs = pd.read_excel(filename, ["metadata", "display_options", "trial_list"])

--- a/src/motor_task_prototype/gui.py
+++ b/src/motor_task_prototype/gui.py
@@ -131,13 +131,27 @@ class MotorTaskGui(QtWidgets.QMainWindow):
             return False
         try:
             if selected_filter == "Excel file (*.xlsx)":
-                self.experiment.save_excel(filename)
+                options = [
+                    "One page for each trial (default)",
+                    "One page for each target",
+                ]
+                option, ok = QtWidgets.QInputDialog.getItem(
+                    self,
+                    "Data export options",
+                    "Data export option:",
+                    options,
+                    editable=False,
+                )
+                if ok is False:
+                    return False
+                data_format = "target" if "target" in option else "trial"
+                self.experiment.save_excel(filename, data_format=data_format)
             elif selected_filter == "JSON file (*.json)":
                 self.experiment.save_json(filename)
             else:
                 raise RuntimeError(f"Selected filter {selected_filter} is not valid.")
         except Exception as e:
-            logging.warning(f"Failed to export to file {filename}: {e}")
+            logging.exception(e)
             QtWidgets.QMessageBox.critical(
                 self,
                 "File export error",


### PR DESCRIPTION
- save_excel(): add `data_format` option
  - "trial": one page per trial
  - "target": one page per target (previous behaviour)
- GUI
  - ask user on excel export which option they want
  - set "trial" as default
- excel format
  - one page for a trial, with timestamps that increase throughout the trial
  - for each timestamp, x/y mouse location, x/y target location, target index
  - target index meaning:
    - `non-negative`: index of visible outer target
    - `-1`: center target is visible
    - `99`: no targets visible
  - target locations also set to `-99` if no target is visible
- docs
  - add "Share experiments" page with info on import/export file formats
- resolves #172
