### PR TITLE
Fix `fixed_target_intervals` option

### DIFF
--- a/docs/quickstart/create-experiment.rst
+++ b/docs/quickstart/create-experiment.rst
@@ -55,7 +55,17 @@ When you are finished, click "OK".
 
    Dialog to edit the settings for a trial.
 
-Note on "Target indices"
-   * if "Target order" is "fixed" then this lists the targets in the order to be displayed
+Notes on trial settings:
+
+* ``Target indices``
+   * if ``Target order`` is ``fixed`` then this lists the targets in the order to be displayed
    * targets are numbered clockwise starting from 0 at the top of the circle
-   * note: if "Target order" is not "fixed" these indices are ignored
+   * note: if ``Target order`` is not ``fixed`` these indices are ignored
+* ``Fixed target display intervals``
+   * if enabled
+      * the next (outer) target is displayed every ``Target display duration`` seconds
+      * this happens regardless of what the user does
+      * the ``Delay between targets`` setting is ignored in this case
+   * if disabled
+      * all targets are displayed until either the user reaches them or ``Target display duration`` seconds elapse
+      * then there is a pause of ``Delay between targets`` seconds before each (outer) target is displayed

--- a/src/motor_task_prototype/__init__.py
+++ b/src/motor_task_prototype/__init__.py
@@ -5,4 +5,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"

--- a/src/motor_task_prototype/vis.py
+++ b/src/motor_task_prototype/vis.py
@@ -314,7 +314,7 @@ def display_results(
 def _make_textbox_press_enter(win: Window) -> TextBox2:
     return TextBox2(
         win,
-        "Press press Enter when you are ready to continue...",
+        "Please press Enter when you are ready to continue...",
         pos=(0, -0.47),
         color="navy",
         alignment="center",


### PR DESCRIPTION
- previous behaviour of this option was confusing and inconsistent
- new behaviour when `fixed_target_intervals=True` and `trial["target_duration"]=x`
  - next outer target shown every `x` seconds
  - this happens regardless of whether the user
    - is moving to an outer target
    - is moving to a central target
    - has successfully moved to their target(s)
- update docs with this information
- resolves https://github.com/ssciwr/motor-task-prototype/issues/171